### PR TITLE
Hotfix interactive support for curl downloaded setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The setup is quite simple:
 
 2. **Run the setup script on the Kittyflap**
    ```bash
-   curl -sSL https://raw.githubusercontent.com/floppyFK/kittyhack/main/setup/kittyhack-setup.sh | sudo bash
+   curl -sSL https://raw.githubusercontent.com/floppyFK/kittyhack/main/setup/kittyhack-setup.sh -o /tmp/kittyhack-setup.sh && chmod +x /tmp/kittyhack-setup.sh && sudo /tmp/kittyhack-setup.sh && rm /tmp/kittyhack-setup.sh
    ```
    You can choose between two options:
    - **install**: Runs the full setup and disables unwanted services on the kittyflap (recommended)
@@ -139,7 +139,7 @@ Die Installation ist kinderleicht:
 
 2. **Das Setup Script auf der Kittyflap ausführen**
    ```bash
-   curl -sSL https://raw.githubusercontent.com/floppyFK/kittyhack/main/setup/kittyhack-setup.sh | sudo bash
+   curl -sSL https://raw.githubusercontent.com/floppyFK/kittyhack/main/setup/kittyhack-setup.sh -o /tmp/kittyhack-setup.sh && chmod +x /tmp/kittyhack-setup.sh && sudo /tmp/kittyhack-setup.sh && rm /tmp/kittyhack-setup.sh
    ```
    Du hast die Auswahl zwischen zwei Optionen:
    - **install**: Führt das komplette Setup aus, inklusive stoppen und entfernen von ungewollten Services auf der Kittyflap (empfohlen)

--- a/setup/kittyhack-setup.sh
+++ b/setup/kittyhack-setup.sh
@@ -251,7 +251,7 @@ EOF
             install_kittyhack
             break
             ;;
-        q)
+        q|"")
             echo -e "${YELLOW}Quitting installation.${NC}"
             exit 0
             ;;


### PR DESCRIPTION
Hotfix for `kittyhack-setup.sh`: Piped script from curl is not executable in interactive mode.  
Changed to download to `/tmp` + chmod + execute