### PR TITLE
fix model submit button

### DIFF
--- a/doc/changelogs/changelog_v2.5.2_de.md
+++ b/doc/changelogs/changelog_v2.5.2_de.md
@@ -1,0 +1,7 @@
+# v2.5.2
+
+Ein weiterer Hotfix für v2.5. Die Änderungen der v2.5.0 sind [hier](https://github.com/floppyFK/kittyhack/blob/main/doc/changelogs/changelog_v2.5.0_de.md) einsehbar.
+
+## Bugfixes
+- **Modelltraining**: Ein Problem wurde behoben, bei dem das Absenden der Trainingsdaten nicht funktioniert, wenn Kittyhack direkt auf einer Kittyflap läuft.
+- **Upload-Ablauf beim Training**: Der Button zum Absenden eines Modelltrainings bleibt jetzt deaktiviert, bis die hochgeladene Trainings-ZIP-Datei vollständig übertragen wurde.

--- a/doc/changelogs/changelog_v2.5.2_en.md
+++ b/doc/changelogs/changelog_v2.5.2_en.md
@@ -1,0 +1,7 @@
+# v2.5.2
+
+Another hotfix for v2.5. The changes for v2.5.0 can be found [here](https://github.com/floppyFK/kittyhack/blob/main/doc/changelogs/changelog_v2.5.0_en.md).
+
+## Bugfixes
+- **Model training**: Fixed an issue where submitting the training data did not work when Kittyhack was running directly on a Kittyflap.
+- **Training upload flow**: The button for submitting a model training now remains disabled until the uploaded training ZIP file has been fully transferred.

--- a/src/server.py
+++ b/src/server.py
@@ -5881,6 +5881,21 @@ def server(input, output, session):
                             ui.hr(),
                             ui.br(),
                             ui.input_task_button("submit_model_training", _("Submit Model for Training"), class_="btn-primary"),
+                            ui.tags.script(
+                                ui.HTML("""
+                                    (function() {
+                                        var btn = document.getElementById('submit_model_training');
+                                        if (!btn) return;
+                                        btn.disabled = true;
+                                        var tid = setInterval(function() {
+                                            if (!document.body.contains(btn)) { clearInterval(tid); return; }
+                                            var bar = document.querySelector('#model_training_data_progress .progress-bar');
+                                            var done = bar && bar.textContent.trim().toLowerCase() === 'upload complete';
+                                            btn.disabled = !done;
+                                        }, 300);
+                                    })();
+                                """)
+                            ),
                             id="model_training_form",
                             style_="display: flex; flex-direction: column; align-items: center; justify-content: center;"
                         ),
@@ -6160,11 +6175,14 @@ def server(input, output, session):
         model_name = input.model_name()
         email_notification = input.email_notification()
         user_name = input.user_name()
-        model_variant = str(input.model_training_base_model() or "n").strip().lower()
-        image_size_raw = str(input.model_training_image_size() or "320").strip()
 
-        # Advanced model parameters are only enabled in remote-mode.
-        if not is_remote_mode():
+        # Advanced model parameters are only available in remote-mode.
+        # In target-mode, the select inputs are not rendered in the DOM,
+        # so accessing them would raise a SilentException.
+        if is_remote_mode():
+            model_variant = str(input.model_training_base_model() or "n").strip().lower()
+            image_size_raw = str(input.model_training_image_size() or "320").strip()
+        else:
             model_variant = "n"
             image_size_raw = "320"
 


### PR DESCRIPTION
## Bugfixes
- **Model training**: Fixed an issue where submitting the training data did not work when Kittyhack was running directly on a Kittyflap.
- **Training upload flow**: The button for submitting a model training now remains disabled until the uploaded training ZIP file has been fully transferred.
