### PR TITLE
Configurable update repository (fork/branch) for testing

### DIFF
--- a/src/baseconfig.py
+++ b/src/baseconfig.py
@@ -269,6 +269,13 @@ DEFAULT_CONFIG = {
         "remote_sync_on_first_connect": True,
         "remote_sync_labelstudio": True,
         "remote_inference_max_fps": 10.0,
+
+        # Update repository override (for testing your own fork or a feature branch).
+        # mode: "standard" -> use floppyFK/kittyhack (release tags)
+        #       "custom"   -> use UPDATE_REPOSITORY value below
+        # UPDATE_REPOSITORY format: "owner/repo" or "owner/repo@branch-or-tag"
+        "update_repository_mode": "standard",
+        "update_repository": "",
     }
 }
 
@@ -537,6 +544,10 @@ def load_config():
         "REMOTE_SYNC_ON_FIRST_CONNECT": safe_bool("REMOTE_SYNC_ON_FIRST_CONNECT", d.get('remote_sync_on_first_connect', True)),
         "REMOTE_SYNC_LABELSTUDIO": safe_bool("REMOTE_SYNC_LABELSTUDIO", d.get('remote_sync_labelstudio', True)),
         "REMOTE_INFERENCE_MAX_FPS": safe_float("REMOTE_INFERENCE_MAX_FPS", float(d.get('remote_inference_max_fps', 10.0))),
+
+        # Update repository override
+        "UPDATE_REPOSITORY_MODE": safe_str("UPDATE_REPOSITORY_MODE", d.get('update_repository_mode', 'standard')),
+        "UPDATE_REPOSITORY": safe_str("UPDATE_REPOSITORY", d.get('update_repository', '')),
     }
 
     # Update in-place so imported CONFIG references in other modules stay valid.
@@ -686,6 +697,8 @@ def save_config():
     settings['restart_ip_camera_stream_on_failure'] = CONFIG['RESTART_IP_CAMERA_STREAM_ON_FAILURE']
     settings['wlan_watchdog_enabled'] = CONFIG['WLAN_WATCHDOG_ENABLED']
     settings['disable_rfid_reader'] = CONFIG['DISABLE_RFID_READER']
+    settings['update_repository_mode'] = CONFIG.get('UPDATE_REPOSITORY_MODE', 'standard')
+    settings['update_repository'] = CONFIG.get('UPDATE_REPOSITORY', '')
 
     # Never persist remote-only settings in config.ini.
     # They are stored in config.remote.ini so they survive sync operations.

--- a/src/helper.py
+++ b/src/helper.py
@@ -441,31 +441,117 @@ def get_local_date_from_utc_date(utc_date_string: str):
     
     return local_date_string
 
-def read_latest_kittyhack_version(timeout=10) -> str:
+# ---------------------------------------------------------------------------
+# Update repository resolution
+# ---------------------------------------------------------------------------
+# By default Kittyhack tracks floppyFK/kittyhack release tags. The CONFIG keys
+# UPDATE_REPOSITORY_MODE / UPDATE_REPOSITORY let users point update checks and
+# installs at a custom fork or a feature branch — useful for testing PRs
+# without publishing a release.
+
+DEFAULT_UPDATE_REPO_OWNER = "floppyFK"
+DEFAULT_UPDATE_REPO_NAME = "kittyhack"
+
+
+def _parse_repo_spec(raw: str):
+    """Parse 'owner/repo' or 'owner/repo@ref' (optionally with URL prefix).
+
+    Returns (owner, repo, ref_or_None) or (None, None, None) if invalid.
     """
-    Reads the latest version of Kittyhack from the GitHub repository.
-    If the version cannot be fetched, it returns 'unknown'.
+    if not raw:
+        return None, None, None
+    raw = raw.strip()
+    m = re.match(
+        r"^(?:https?://github\.com/)?([\w.-]+)/([\w.-]+?)(?:\.git)?(?:@([\w./\-]+))?$",
+        raw,
+    )
+    if not m:
+        return None, None, None
+    return m.group(1), m.group(2), m.group(3) or None
+
+
+def resolved_update_repo():
+    """Resolve the active update source based on CONFIG.
+
+    Returns a tuple (owner, repo, ref, git_url, mode):
+        - owner, repo: GitHub owner / repository
+        - ref: branch or tag name, or None -> use latest release
+        - git_url: https clone URL suitable for `git remote set-url`
+        - mode: "standard" or "custom"
+    Invalid custom values silently fall back to the default.
     """
     try:
+        from src.baseconfig import CONFIG
+        mode = str(CONFIG.get("UPDATE_REPOSITORY_MODE") or "standard").strip().lower()
+        if mode == "custom":
+            owner, repo, ref = _parse_repo_spec(CONFIG.get("UPDATE_REPOSITORY") or "")
+            if owner and repo:
+                return owner, repo, ref, f"https://github.com/{owner}/{repo}.git", "custom"
+            logging.warning(
+                f"[UPDATE] Invalid custom repository spec '{CONFIG.get('UPDATE_REPOSITORY', '')}'; "
+                f"falling back to {DEFAULT_UPDATE_REPO_OWNER}/{DEFAULT_UPDATE_REPO_NAME}"
+            )
+    except Exception as e:
+        logging.debug(f"[UPDATE] resolved_update_repo fell back to default: {e}")
+    return (
+        DEFAULT_UPDATE_REPO_OWNER,
+        DEFAULT_UPDATE_REPO_NAME,
+        None,
+        f"https://github.com/{DEFAULT_UPDATE_REPO_OWNER}/{DEFAULT_UPDATE_REPO_NAME}.git",
+        "standard",
+    )
+
+
+def read_latest_kittyhack_version(timeout=10) -> str:
+    """
+    Reads the latest version of Kittyhack from the configured GitHub repository.
+
+    Standard / tag mode (ref is None): returns the tag_name of the latest release.
+    Branch mode (ref is set): returns "<ref>@<short-sha>" of the branch head, so
+    the UI's "update available?" check still works by string comparison.
+    Returns 'unknown' on failure.
+    """
+    owner, repo, ref, _git_url, _mode = resolved_update_repo()
+    try:
         ts_pre = tm.time()
-        response = requests.get("https://api.github.com/repos/floppyFK/kittyhack/releases/latest", timeout=timeout)
-        ts_post = tm.time()
-        latest_version = str(response.json().get("tag_name", "unknown"))
-        logging.info(f"GitHub latest version fetch took {ts_post - ts_pre:.3f} seconds. Latest version: {latest_version}")
+        if ref is None:
+            url = f"https://api.github.com/repos/{owner}/{repo}/releases/latest"
+            response = requests.get(url, timeout=timeout)
+            ts_post = tm.time()
+            latest_version = str(response.json().get("tag_name", "unknown"))
+        else:
+            url = f"https://api.github.com/repos/{owner}/{repo}/commits/{ref}"
+            response = requests.get(url, timeout=timeout)
+            ts_post = tm.time()
+            sha = str(response.json().get("sha", "") or "")[:7]
+            latest_version = f"{ref}@{sha}" if sha else "unknown"
+        logging.info(
+            f"GitHub latest version fetch took {ts_post - ts_pre:.3f} seconds "
+            f"({owner}/{repo}{'@' + ref if ref else ''}). Latest: {latest_version}"
+        )
         return latest_version
     except Exception as e:
-        logging.error(f"Failed to fetch the latest version from GitHub: {e}")
+        logging.error(f"Failed to fetch the latest version from GitHub ({owner}/{repo}): {e}")
         return "unknown"
-    
+
+
 def fetch_github_release_notes(version: str) -> str:
     """
-    Fetches the release notes for a specific version from the Kittyhack GitHub repository.
-    Args:
-        version (str): The version tag (e.g., 'v2.0.0' or '2.0.0').
-    Returns:
-        str: The release notes (body) or an error message.
+    Fetches release notes for a specific version from the configured repository.
+
+    In branch mode (ref is set in the resolved repo) there are no releases, so
+    we return a short human-readable note pointing at the branch HEAD instead.
     """
-    url = "https://api.github.com/repos/floppyFK/kittyhack/releases"
+    owner, repo, ref, _git_url, _mode = resolved_update_repo()
+
+    if ref is not None:
+        # Branch mode — no release notes concept.
+        return (
+            f"You are tracking branch **{ref}** of **{owner}/{repo}**.\n\n"
+            f"No release notes are published for branches. Latest commit: `{version}`."
+        )
+
+    url = f"https://api.github.com/repos/{owner}/{repo}/releases"
     try:
         response = requests.get(url, timeout=5)
         response.raise_for_status()

--- a/src/server.py
+++ b/src/server.py
@@ -6536,6 +6536,42 @@ def server(input, output, session):
                             ui.column(12, ui.markdown(_("Automatically check for new versions of Kittyhack.")), style_="color: grey;"),
                         ),
                         ui.hr(),
+                        ui.row(
+                            ui.column(
+                                6,
+                                ui.input_select(
+                                    "update_repository_mode",
+                                    _("Update repository"),
+                                    {"standard": _("Standard"), "custom": _("Custom")},
+                                    selected=CONFIG.get('UPDATE_REPOSITORY_MODE', 'standard'),
+                                ),
+                            ),
+                            ui.column(
+                                6,
+                                ui.input_text(
+                                    "update_repository",
+                                    _("Custom repository"),
+                                    value=CONFIG.get('UPDATE_REPOSITORY', ''),
+                                    placeholder=_("e.g. owner/repo or owner/repo@branch"),
+                                    width="100%",
+                                ),
+                                id="update_repository_container",
+                            ),
+                            ui.column(
+                                12,
+                                ui.markdown(
+                                    _(
+                                        "Use **Standard** for official releases from `floppyFK/kittyhack`. "
+                                        "Select **Custom** to test your own fork or a feature branch. "
+                                        "Format: `owner/repo` (uses the repo's latest release tag) or "
+                                        "`owner/repo@branch-or-tag` (tracks the specified ref)."
+                                    )
+                                ),
+                                style_="color: grey;",
+                                id="update_repository_help",
+                            ),
+                        ),
+                        ui.hr(),
                         (
                             ui.row(
                                 ui.column(12, ui.markdown(_("WLAN settings are not available in remote-mode.")), style_="color: grey;")
@@ -7664,6 +7700,21 @@ def server(input, output, session):
             if not valid:
                 return
             
+        # Validate custom update repository spec when "custom" mode is selected.
+        if input.update_repository_mode() == "custom":
+            raw_repo_spec = (input.update_repository() or "").strip()
+            if not re.match(
+                r"^(?:https?://github\.com/)?[\w.-]+/[\w.-]+?(?:\.git)?(?:@[\w./\-]+)?$",
+                raw_repo_spec,
+            ):
+                ui.notification_show(
+                    _("Update repository: ") +
+                    _("Invalid format. Use 'owner/repo' or 'owner/repo@branch-or-tag'.") + "\n" +
+                    _("Changes were not saved."),
+                    duration=10, type="error"
+                )
+                return
+
         # Check for a changed hostname
         hostname_changed = input.txtHostname() != get_hostname()
         if hostname_changed:
@@ -7756,6 +7807,8 @@ def server(input, output, session):
         from src.baseconfig import AllowedToExit as ATE
         CONFIG['ALLOWED_TO_EXIT'] = ATE(input.btnAllowedToExit())
         CONFIG['PERIODIC_VERSION_CHECK'] = input.btnPeriodicVersionCheck()
+        CONFIG['UPDATE_REPOSITORY_MODE'] = input.update_repository_mode()
+        CONFIG['UPDATE_REPOSITORY'] = (input.update_repository() or "").strip()
         # TODO: Outside PIR shall not yet be configurable. Need to redesign the camera control, otherwise we will have no cat pictures at high PIR thresholds.
         #CONFIG['PIR_OUTSIDE_THRESHOLD'] = 10-int(input.sldPirOutsideThreshold())
         CONFIG['PIR_INSIDE_THRESHOLD'] = float(input.sldPirInsideThreshold())

--- a/src/system.py
+++ b/src/system.py
@@ -790,6 +790,16 @@ def update_kittyhack(
     req_hash_after: str | None = None
     did_update_deps = False
 
+    # Resolve the configured update source (standard vs custom repo / branch).
+    try:
+        from src.helper import resolved_update_repo
+        update_owner, update_repo, update_ref, update_git_url, update_mode = resolved_update_repo()
+    except Exception as e:
+        logging.debug(f"[UPDATE] resolved_update_repo not available ({e}); using existing origin")
+        update_git_url = None
+        update_ref = None
+        update_mode = "standard"
+
     try:
         # 1
         _run_step(1, "Reverting local changes", ["/bin/git", "restore", "."])
@@ -799,10 +809,32 @@ def update_kittyhack(
         # Hash current requirements after a clean tree, so the comparison is meaningful.
         req_hash_before = _sha256_file(requirements_path)
 
+        # Point origin at the configured update source (best-effort).
+        if update_git_url:
+            try:
+                subprocess.run(
+                    ["/bin/git", "remote", "set-url", "origin", update_git_url],
+                    cwd=kittyhack_root(),
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+                logging.info(f"[UPDATE] origin URL set to {update_git_url} (mode={update_mode})")
+            except Exception as e:
+                logging.warning(f"[UPDATE] Failed to update origin URL to {update_git_url}: {e}")
+
         # 3
         _run_step(3, f"Fetching latest version {latest_version}", ["/bin/git", "fetch", "--all", "--tags"])
-        # 4
-        _run_step(4, f"Checking out {latest_version}", ["/bin/git", "checkout", latest_version])
+        # 4 — checkout either a tag (standard / custom+tag) or a branch (custom+branch).
+        if update_ref is not None:
+            # Branch mode: create/reset a local branch tracking origin/<ref> to HEAD.
+            _run_step(
+                4,
+                f"Checking out branch {update_ref}",
+                ["/bin/git", "checkout", "-B", update_ref, f"origin/{update_ref}"],
+            )
+        else:
+            _run_step(4, f"Checking out {latest_version}", ["/bin/git", "checkout", latest_version])
 
         req_hash_after = _sha256_file(requirements_path)
         requirements_unchanged = (

--- a/www/server-ui.js
+++ b/www/server-ui.js
@@ -174,6 +174,28 @@
         sel.addEventListener('change', apply, true);
     }
 
+    function initUpdateRepoToggle() {
+        // Toggle custom repository input/help visibility based on #update_repository_mode.
+        // Expects containers: #update_repository_container, #update_repository_help
+        var sel = q('#update_repository_mode');
+        var urlWrap = q('#update_repository_container');
+        var helpWrap = q('#update_repository_help');
+        if (!sel || (!urlWrap && !helpWrap)) return;
+
+        if (sel.getAttribute('data-kh-updaterepo-bound') === '1') return;
+        sel.setAttribute('data-kh-updaterepo-bound', '1');
+
+        function apply() {
+            var isCustom = false;
+            try { isCustom = (String(sel.value) === 'custom'); } catch (e) {}
+            if (urlWrap) urlWrap.style.display = isCustom ? '' : 'none';
+            if (helpWrap) helpWrap.style.display = isCustom ? '' : 'none';
+        }
+
+        apply();
+        sel.addEventListener('change', apply, true);
+    }
+
     function initLogicToggles() {
         // Handles "Show decision logic" blocks for entry and exit.
         if (!onceFlag(window, '__khLogicToggleGlobal')) return;
@@ -330,6 +352,7 @@
         initTooltipWrappers(scope);
         // These run opportunistically when the corresponding UI is present.
         initIpCameraUrlToggle();
+        initUpdateRepoToggle();
         initLogicToggles();
         initManageCatsRFIDValidation();
         initUpdateProgressModal();


### PR DESCRIPTION
## Summary

Adds two config fields so users can point update **check** and **install** at a custom fork or feature branch instead of always tracking `floppyFK/kittyhack` releases. Motivation: testing PRs on a real Kittyflap without having to publish a release.

Default behaviour is unchanged — Standard mode still points at `floppyFK/kittyhack`.

### User-visible change

In the **Configuration** tab (General settings) there is a new **Update repository** select:

- **Standard** — release tags from `floppyFK/kittyhack` (today's behaviour)
- **Custom** — reveals a text field accepting:
  - `owner/repo` → that repo's **latest release tag**
  - `owner/repo@branch-or-tag` → track that exact ref (branch HEAD or specific tag)

The text field is validated on save and hidden via JS when mode = Standard (same pattern as the existing IP-camera-URL toggle).

### Code changes

- **`src/baseconfig.py`** — new keys `UPDATE_REPOSITORY_MODE` (default \`standard\`) and `UPDATE_REPOSITORY` (default \`\`). Same defaults / safe_str / save_config pattern as existing settings.
- **`src/helper.py`** — new `resolved_update_repo()` helper returns `(owner, repo, ref, git_url, mode)`. `read_latest_kittyhack_version()` and `fetch_github_release_notes()` refactored to use it.
  - In branch mode, latest version becomes `<ref>@<sha7>` so the UI's existing \`git_version != latest_version\` comparison still works and shows the Update button when the branch has moved.
  - Branch mode release notes: short explanatory note instead of a GitHub-releases lookup that would return nothing.
- **`src/system.py`** `update_kittyhack()` — before `git fetch`: `git remote set-url origin <resolved_url>` (best-effort, logged). In branch mode, checkout becomes `git checkout -B <ref> origin/<ref>` so subsequent updates pick up new commits on the branch. Existing rollback logic is untouched.
- **`src/server.py`** — Configuration tab select + conditional text input, save-time regex validation, writes CONFIG on save.
- **`www/server-ui.js`** — new `initUpdateRepoToggle()` following the existing IP-camera toggle pattern, registered in `initAll()`.

### Test plan

- [ ] Fresh install: Standard mode works identically — version check and update continue to use floppyFK releases.
- [ ] Switch to Custom, enter \`FabulousGee/kittyhack\`, save. Info tab shows that fork's latest release as \"latest version\". Update installs from the fork.
- [ ] Enter \`FabulousGee/kittyhack@feat/rest-api\`, save. Info tab shows \`feat/rest-api@<sha7>\`. Clicking update checks out the branch head (\`git checkout -B feat/rest-api origin/feat/rest-api\`).
- [ ] Enter an invalid value (e.g. \`not-a-repo\`), save — save is refused with a notification; no CONFIG change.
- [ ] Switch back to Standard, save: \`origin\` URL is reset on next update; subsequent update pulls from floppyFK again.
- [ ] Update failure on custom source: existing rollback restores the previous version.

### Scope note

This PR is independent of #153 (REST API). Both branches are rebased on the latest `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)