### PR TITLE
fix(backend): inside unlock blocked for 30 min after every restart

### DIFF
--- a/doc/changelogs/changelog_v2.5.5_de.md
+++ b/doc/changelogs/changelog_v2.5.5_de.md
@@ -1,0 +1,6 @@
+# v2.5.5
+
+Hotfix für eine Aussperrung, die in den ersten ~30 Minuten nach jedem Neustart auftreten konnte (inkl. dem Neustart, der durch das v2.5.4-Update selbst ausgelöst wurde).
+
+## Bugfixes
+- **Katze konnte ~30 Minuten nach einem Neustart nicht hereinkommen**: Das Gate „keine Beute innerhalb der Timeout-Zeit erkannt" in der Innen-Entriegelungslogik verwendete einen naiven Zeitvergleich, der den nicht initialisierten Wert `prey_detection_mono` (`0.0`) so behandelte, als sei „gerade eben Beute erkannt worden". Weil die monotone Uhr direkt nach dem Boot klein ist, war das errechnete Alter kleiner als `LOCK_DURATION_AFTER_PREY_DETECTION` (Standard: 1800 s), und das Gate blieb für die ersten 30 Minuten der Uptime geschlossen — obwohl in dieser Session nie Beute erkannt wurde. Nach einem Neustart konnten RFID-Erkennung, Bewegungserkennung und Mouse-Check alle erfolgreich sein, während die Tür sich trotzdem nicht entriegelte. Der Fix bricht den Vergleich ab, wenn `prey_detection_mono` nie gesetzt wurde, analog zur Schutzprüfung, die bereits im Prey-State-Publisher vorhanden war.

--- a/doc/changelogs/changelog_v2.5.5_en.md
+++ b/doc/changelogs/changelog_v2.5.5_en.md
@@ -1,0 +1,6 @@
+# v2.5.5
+
+Hotfix for a lockout that could occur in the first ~30 minutes after any service restart (including the one triggered by the v2.5.4 update itself).
+
+## Bugfixes
+- **Cat could not enter for ~30 minutes after a restart**: The "no prey detected within timeout" gate of the inside-unlock logic used a naive time comparison that treated the uninitialised `prey_detection_mono` value (`0.0`) as "prey was just detected". Because the monotonic clock starts small right after boot, the resulting age was smaller than `LOCK_DURATION_AFTER_PREY_DETECTION` (default 1800 s), so the gate stayed closed for the first 30 minutes of uptime — even though no prey had ever been detected in that session. After a restart, RFID detection, motion detection and mouse-check could all succeed while the door still refused to unlock. The fix short-circuits the comparison when `prey_detection_mono` has never been set, mirroring the guard that already existed in the prey-state publisher.

--- a/src/backend.py
+++ b/src/backend.py
@@ -1004,9 +1004,16 @@ def backend_main(simulate_kittyflap = False):
             # ignore the global prey timeout gate for unlocking. This ensures that
             # late RFID identification can still disable prey gating even if prey was
             # detected a few seconds earlier by the camera.
+            # prey_detection_mono == 0.0 means no prey has been detected since the
+            # backend started — treat that as "timeout elapsed", otherwise the check
+            # would falsely block the unlock for LOCK_DURATION_AFTER_PREY_DETECTION
+            # seconds after every service restart (monotonic_time() is small just
+            # after boot, so the difference would be < the configured duration).
+            prey_mono = float(getattr(backend_main, "prey_detection_mono", 0.0) or 0.0)
             no_prey_within_timeout_effective = (
                 True if per_cat_prey_detection_disabled
-                else (monotonic_time() - float(getattr(backend_main, "prey_detection_mono", 0.0) or 0.0)) > float(CONFIG['LOCK_DURATION_AFTER_PREY_DETECTION'])
+                else prey_mono == 0.0
+                or (monotonic_time() - prey_mono) > float(CONFIG['LOCK_DURATION_AFTER_PREY_DETECTION'])
             )
 
             unlock_inside_conditions = {


### PR DESCRIPTION
## Summary
- A user upgraded to v2.5.4 on 2026-04-19. Over the following hours their cat tried to enter the flap at least a dozen times and was locked out each time, despite valid RFID, motion, mouse-check and both locks cleared. In each case the log shows the same failing condition:

```
[BACKEND] Unlock inside conditions: {'motion_outside': True, 'tag_id_valid': True,
  'inside_locked': True, 'mouse_check': True, 'outside_locked': True,
  'no_unlock_queued': True, 'no_prey_within_timeout': False,
  'not_manually_locked': True}
```

- `no_prey_within_timeout` was `False` — but no prey had been detected at any point in that session. Looking at the check in `src/backend.py`:

```python
no_prey_within_timeout_effective = (
    True if per_cat_prey_detection_disabled
    else (monotonic_time() - float(getattr(backend_main, "prey_detection_mono", 0.0) or 0.0))
         > float(CONFIG['LOCK_DURATION_AFTER_PREY_DETECTION'])
)
```

  `prey_detection_mono` is initialised to `0.0` and only set when prey is actually detected by the model. Against an unset `0.0`, the expression reduces to `monotonic_time() > LOCK_DURATION_AFTER_PREY_DETECTION` — i.e. "has the backend been up for 30 minutes?". For the first 30 minutes of uptime the gate therefore reports "prey was just detected" even when no prey has ever been detected.

- **Impact**: every service restart (including the one the v2.5.4 update itself triggers, plus any reboot for other reasons) starts a 30-minute window during which the inside unlock is incorrectly blocked. In the reporting user's logs this window lined up with multiple cat arrivals across four restarts in one evening.

- **Fix**: short-circuit the comparison when `prey_detection_mono` has never been set — exactly the same guard that already exists a few hundred lines up in the prey-state publisher (`src/backend.py:263-265`).

## Relation to v2.5.4

The buggy code is older than v2.5.4 (no v2.5.4 commit touches `src/backend.py`). v2.5.4 did not introduce it — but the mandatory service restart that the update performs is what made users hit it now.

## Evidence (from the reporting user's `journalctl.log`)

Four post-update restarts on 2026-04-19 (22:11 / 22:58 / 23:28 / 23:48) and one the next morning (10:22). The cat approached during each 30-minute blackout:

| Time                  | Minutes after restart | `no_prey_within_timeout` |
|-----------------------|-----------------------|--------------------------|
| 2026-04-19T22:28:14   | ~17                   | False                    |
| 2026-04-19T22:31:55   | ~20                   | False                    |
| 2026-04-19T23:06:40   | ~8                    | False                    |
| 2026-04-19T23:13:57   | ~16                   | False                    |
| 2026-04-19T23:45:49   | ~17                   | False                    |
| 2026-04-20T10:29:50   | ~7                    | False                    |

On 2026-04-20 the flag flipped to `True` at 10:52:46 — 30 minutes after the 10:22 boot — confirming the uptime-driven behaviour.

## Test plan
- [ ] After deploying this branch, restart `kittyhack.service` and verify `[BACKEND] Unlock inside conditions: ... 'no_prey_within_timeout': True ...` appears in the very first conditions dump (not after 30 minutes).
- [ ] Trigger a real prey detection and confirm the gate still closes for the configured duration (`LOCK_DURATION_AFTER_PREY_DETECTION`), i.e. the fix doesn't disable prey gating — it only fixes the uninitialised case.
- [ ] Per-cat prey detection disabled path still bypasses the gate (`True if per_cat_prey_detection_disabled`) — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)