### PR TITLE
fix(model): handle abandoned job results in pir based mode

### DIFF
--- a/doc/changelogs/changelog_v2.5.5_de.md
+++ b/doc/changelogs/changelog_v2.5.5_de.md
@@ -1,6 +1,7 @@
 # v2.5.5
 
-Hotfix für eine Aussperrung, die in den ersten ~30 Minuten nach jedem Neustart auftreten konnte (inkl. dem Neustart, der durch das v2.5.4-Update selbst ausgelöst wurde).
+Hotfix-Release für zwei Fehler, die nach einem Neustart bzw. bei PIR-basierter Bewegungserkennung auftreten konnten.
 
 ## Bugfixes
-- **Katze konnte ~30 Minuten nach einem Neustart nicht hereinkommen**: Das Gate „keine Beute innerhalb der Timeout-Zeit erkannt" in der Innen-Entriegelungslogik verwendete einen naiven Zeitvergleich, der den nicht initialisierten Wert `prey_detection_mono` (`0.0`) so behandelte, als sei „gerade eben Beute erkannt worden". Weil die monotone Uhr direkt nach dem Boot klein ist, war das errechnete Alter kleiner als `LOCK_DURATION_AFTER_PREY_DETECTION` (Standard: 1800 s), und das Gate blieb für die ersten 30 Minuten der Uptime geschlossen — obwohl in dieser Session nie Beute erkannt wurde. Nach einem Neustart konnten RFID-Erkennung, Bewegungserkennung und Mouse-Check alle erfolgreich sein, während die Tür sich trotzdem nicht entriegelte. Der Fix bricht den Vergleich ab, wenn `prey_detection_mono` nie gesetzt wurde, analog zur Schutzprüfung, die bereits im Prey-State-Publisher vorhanden war.
+- **Eingangsrichtung nach Neustart vorübergehend blockiert**: Nach einem Neustart war die Eingangsrichtung für die Dauer von der Einstellung *Verriegelungsdauer nach Beuteerkennung* blockiert, obwohl in der aktuellen Laufzeit noch keine Beute erkannt wurde.
+- **Hohe CPU-Last bei PIR-basierter Bewegungserkennung**: Bei deaktivierter Option *Kamera für die Bewegungserkennung verwenden* (also PIR-Betrieb) konnte es zu hoher CPU-Last und fortlaufenden Log-Einträgen kommen.

--- a/doc/changelogs/changelog_v2.5.5_en.md
+++ b/doc/changelogs/changelog_v2.5.5_en.md
@@ -1,6 +1,7 @@
 # v2.5.5
 
-Hotfix for a lockout that could occur in the first ~30 minutes after any service restart (including the one triggered by the v2.5.4 update itself).
+Hotfix release for two issues that could occur after a restart or when using PIR-based motion detection.
 
 ## Bugfixes
-- **Cat could not enter for ~30 minutes after a restart**: The "no prey detected within timeout" gate of the inside-unlock logic used a naive time comparison that treated the uninitialised `prey_detection_mono` value (`0.0`) as "prey was just detected". Because the monotonic clock starts small right after boot, the resulting age was smaller than `LOCK_DURATION_AFTER_PREY_DETECTION` (default 1800 s), so the gate stayed closed for the first 30 minutes of uptime — even though no prey had ever been detected in that session. After a restart, RFID detection, motion detection and mouse-check could all succeed while the door still refused to unlock. The fix short-circuits the comparison when `prey_detection_mono` has never been set, mirroring the guard that already existed in the prey-state publisher.
+- **Entry direction temporarily blocked after restart**: After a restart, the entry direction was blocked for the duration configured by the *Lock duration after prey detection* setting, even though no prey had been detected yet in the current runtime.
+- **High CPU load with PIR-based motion detection**: When the option *Use camera for motion detection* was disabled (i.e., PIR mode), this could cause high CPU load and continuous log entries.

--- a/src/model.py
+++ b/src/model.py
@@ -1323,12 +1323,17 @@ class ModelHandler:
             while True:
                 try:
                     result_job_id, mouse_prob, cat_prob, objects = self._output_queue.get(timeout=timeout)
-                    self._job_results[result_job_id] = (mouse_prob, cat_prob, objects)
-                    
-                    if result_job_id == job_id:
-                        return self._job_results.pop(job_id)
-                except:
+                except Exception:
                     return None
+
+                # Drop results that arrived later than expected for an already-abandoned job_id.
+                if result_job_id < job_id:
+                    continue
+
+                self._job_results[result_job_id] = (mouse_prob, cat_prob, objects)
+                
+                if result_job_id == job_id:
+                    return self._job_results.pop(job_id)
         except Exception as e:
             logging.error(f"[MODEL] Error getting result: {e}")
             return None
@@ -1496,10 +1501,19 @@ class ModelHandler:
                 # Start timer (for calculating frame rate)
                 t1 = cv2.getTickCount()
 
-                # Run at least one inference to initialize the model, even if paused
-                if first_run or not self.paused:
-                    # Grab frame from video stream
-                    frame = videostream.read_oldest()
+                # When paused (after the initial warm-up iteration that primes the
+                # YOLO worker so the next real inference is fast), skip the entire
+                # inference + buffer-append work. Without this, the worker process
+                # keeps re-processing the last frame at full FPS, pegging a CPU core
+                # and leaking memory in self._job_results.
+                if not first_run and self.paused:
+                    elapsed_time = (cv2.getTickCount() - t1) / freq
+                    sleep_time = max(0.0, 0.1 - elapsed_time)  # poll for resume at ~10 Hz
+                    tm.sleep(sleep_time)
+                    continue
+
+                # Grab frame from video stream
+                frame = videostream.read_oldest()
 
                 if frame is not None:
                     last_good_frame_ts = tm.time()


### PR DESCRIPTION
## Bugfix
- **High CPU load with PIR-based motion detection**: When the option *Use camera for motion detection* was disabled (i.e., PIR mode), this could cause high CPU load and continuous log entries.