### PR TITLE
Fast lock after pass flap

### DIFF
--- a/doc/changelogs/changelog_v2.6.1_de.md
+++ b/doc/changelogs/changelog_v2.6.1_de.md
@@ -1,0 +1,7 @@
+# v2.6.1
+
+## Neues Feature
+- **Sofortiges Verriegeln nach Passieren (optional)**: Unter *Konfiguration* gibt es eine neue Option, die die Klappe direkt wieder verriegelt, sobald die Katze auf der gegenüberliegenden Seite erkannt wurde. Dadurch bleibt die Klappe kürzer offen und die Gefahr der Passage einer weiteren Katze wird verringert.
+
+## Verbesserungen
+- **Bessere ausklappbare Event-Details auf Mobilgeräten**: Event-Details lassen sich nun über einen einfachen Klick auf den Event-Eintrag auf- und zuklappen.

--- a/doc/changelogs/changelog_v2.6.1_de.md
+++ b/doc/changelogs/changelog_v2.6.1_de.md
@@ -3,5 +3,8 @@
 ## Neues Feature
 - **Sofortiges Verriegeln nach Passieren (optional)**: Unter *Konfiguration* gibt es eine neue Option, die die Klappe direkt wieder verriegelt, sobald die Katze auf der gegenüberliegenden Seite erkannt wurde. Dadurch bleibt die Klappe kürzer offen und die Gefahr der Passage einer weiteren Katze wird verringert.
 
+## Bugfixes
+- **Sporadisch blockierte Eingangsrichtung**: In bestimmten konfigurationen war sporadisch kein Eingang mehr für die Katzen möglich. Dies ist nun gefixt.
+
 ## Verbesserungen
 - **Bessere ausklappbare Event-Details auf Mobilgeräten**: Event-Details lassen sich nun über einen einfachen Klick auf den Event-Eintrag auf- und zuklappen.

--- a/doc/changelogs/changelog_v2.6.1_de.md
+++ b/doc/changelogs/changelog_v2.6.1_de.md
@@ -4,7 +4,7 @@
 - **Sofortiges Verriegeln nach Passieren (optional)**: Unter *Konfiguration* gibt es eine neue Option, die die Klappe direkt wieder verriegelt, sobald die Katze auf der gegenüberliegenden Seite erkannt wurde. Dadurch bleibt die Klappe kürzer offen und die Gefahr der Passage einer weiteren Katze wird verringert.
 
 ## Bugfixes
-- **Sporadisch blockierte Eingangsrichtung**: In bestimmten konfigurationen war sporadisch kein Eingang mehr für die Katzen möglich. Dies ist nun gefixt.
+- **Sporadisch blockierte Eingangsrichtung**: In bestimmten Konfigurationen war sporadisch kein Eingang mehr für die Katzen möglich. Dies ist nun gefixt.
 
 ## Verbesserungen
 - **Bessere ausklappbare Event-Details auf Mobilgeräten**: Event-Details lassen sich nun über einen einfachen Klick auf den Event-Eintrag auf- und zuklappen.

--- a/doc/changelogs/changelog_v2.6.1_en.md
+++ b/doc/changelogs/changelog_v2.6.1_en.md
@@ -1,0 +1,7 @@
+# v2.6.1
+
+## New Feature
+- **Immediate locking after passage (optional)**: A new setting under *Configuration* can lock the flap immediately once the cat is detected on the opposite side (crossing completed). This can reduce the time the flap remains open and helps reducing quick follow-up passages of other cats.
+
+## Improvements
+- **Better expandable event details on mobile**: Event details are now expand/collapse via a simple click on the event row.

--- a/doc/changelogs/changelog_v2.6.1_en.md
+++ b/doc/changelogs/changelog_v2.6.1_en.md
@@ -3,5 +3,8 @@
 ## New Feature
 - **Immediate locking after passage (optional)**: A new setting under *Configuration* can lock the flap immediately once the cat is detected on the opposite side (crossing completed). This can reduce the time the flap remains open and helps reducing quick follow-up passages of other cats.
 
+## Bugfixes
+- **Intermittently blocked entry direction**: In certain configurations, cats were occasionally unable to enter anymore. This issue has now been fixed.
+
 ## Improvements
 - **Better expandable event details on mobile**: Event details are now expand/collapse via a simple click on the event row.

--- a/locales/de/LC_MESSAGES/messages.po
+++ b/locales/de/LC_MESSAGES/messages.po
@@ -4526,3 +4526,46 @@ msgstr "Für dieses Ereignis wurde keine detaillierte Zeitleiste aufgezeichnet."
 
 #~ msgid "Debug details"
 #~ msgstr "Debug Details"
+
+msgid "Immediate locking after passage"
+msgstr "Sofortige Verriegelung nach Durchgang"
+
+msgid "About this feature"
+msgstr "Erklärung zu diesem Feature"
+
+msgid ""
+"When enabled, the flap locks again and the motion event is finalized as "
+"soon as motion is detected on the opposite side of the flap (cat has "
+"crossed)."
+msgstr ""
+"Wenn aktiviert, wird die Klappe wieder verriegelt und das Bewegungsereignis "
+"abgeschlossen, sobald auf der gegenüberliegenden Seite der Klappe eine "
+"Bewegung erkannt wird (Katze hat die Klappe passiert)."
+
+msgid ""
+"This feature is useful if your cat is very fast and the flap should not remain "
+"open for too long. Will help prevent multiple cats from using the flap in "
+"quick succession."
+msgstr ""
+"Dieses Feature ist nützlich, wenn deine Katze sehr schnell ist und die Klappe "
+"nicht zu lange offen bleiben sollte. Es kann dabei helfen, zu verhindern, dass "
+"mehrere Katzen die Klappe kurz nacheinander benutzen."
+
+msgid ""
+"If your cat is shy or just needs several attempts to cross, you should not "
+"enable this feature. Otherwise, the flap could be accidentally locked while "
+"your cat is still trying to cross."
+msgstr ""
+"Wenn deine Katze schüchtern ist oder mehrere Versuche benötigt, um die Klappe "
+"zu passieren, solltest du dieses Feature nicht aktivieren. Andernfalls könnte "
+"die Klappe versehentlich verriegelt werden, während deine Katze noch versucht, "
+"sie zu passieren."
+
+msgid "Cat crossed the flap"
+msgstr "Katze hat die Klappe passiert"
+
+msgid "Inside locked (after passage)"
+msgstr "Innen verriegelt (nach Durchgang)"
+
+msgid "Outside locked (after passage)"
+msgstr "Außen verriegelt (nach Durchgang)"

--- a/src/backend.py
+++ b/src/backend.py
@@ -427,8 +427,9 @@ def backend_main(simulate_kittyflap = False):
     exit_in_progress = False
     motion_block_active = False
     suppress_outside_motion_block = False
-    last_outside_sensor = 0
-    motion_outside_sensor = 0
+    suppress_inside_motion_block = False
+    last_outside_crossing = 0
+    last_inside_crossing = 0
 
     # Register task in the sigterm_monitor object
     sigterm_monitor.register_task()
@@ -580,6 +581,7 @@ def backend_main(simulate_kittyflap = False):
         nonlocal exit_in_progress
         nonlocal motion_block_active
         nonlocal suppress_outside_motion_block
+        nonlocal suppress_inside_motion_block
         nonlocal unlock_inside_tm
         nonlocal timeline_outside_reported
 
@@ -606,6 +608,7 @@ def backend_main(simulate_kittyflap = False):
                     timeline_append(motion_timeline_entries, TimelineAction.OUTSIDE_CLOSED_FAST_IN_OUT)
                 magnets.queue_command("lock_outside")
             suppress_outside_motion_block = True
+            suppress_inside_motion_block = True
         elif (
             magnets.get_inside_state() == True
             and magnets.check_queued("lock_inside") == False
@@ -829,7 +832,8 @@ def backend_main(simulate_kittyflap = False):
             last_outside = motion_outside
             last_inside = motion_inside
             last_inside_raw = motion_inside_raw
-            last_outside_sensor_prev = last_outside_sensor
+            last_outside_crossing_prev = last_outside_crossing
+            last_inside_crossing_prev = last_inside_crossing
 
             if use_camera_for_motion:
                 # Decide if motion occured currently. Look up to 5 seconds into the past for images with cats
@@ -842,10 +846,9 @@ def backend_main(simulate_kittyflap = False):
             else:
                 motion_outside, motion_inside, motion_outside_raw, motion_inside_raw = pir.get_states()
 
-            if use_camera_for_motion:
-                motion_outside_sensor = motion_outside
-            else:
-                motion_outside_sensor = motion_outside_raw
+            # Threshold-filtered motion (not raw PIR) for immediate-lock crossing detection.
+            motion_outside_crossing = motion_outside
+            motion_inside_crossing = motion_inside
 
             # Update the motion timestamps
             if motion_outside == 1:
@@ -887,8 +890,10 @@ def backend_main(simulate_kittyflap = False):
                 rfid_thread.start()
 
             # Outside motion stopped
-            if suppress_outside_motion_block and motion_outside == 0 and motion_outside_sensor == 0:
+            if suppress_outside_motion_block and motion_outside == 0 and motion_outside_crossing == 0:
                 suppress_outside_motion_block = False
+            if suppress_inside_motion_block and motion_inside == 0 and motion_inside_crossing == 0:
+                suppress_inside_motion_block = False
 
             if last_outside == 1 and motion_outside == 0:
                 if not use_camera_for_motion:
@@ -951,7 +956,48 @@ def backend_main(simulate_kittyflap = False):
                 first_motion_inside_raw_tm = wall_time()
                 first_motion_inside_raw_mono = monotonic_time()
 
-            if last_inside == 0 and motion_inside == 1: # Inside motion detected
+            if CONFIG.get('IMMEDIATE_LOCK_AFTER_PASSAGE'):
+                fast_crossing = False
+                if (
+                    motion_block_active
+                    and exit_in_progress
+                    and unlock_outside_tm > 0.0
+                    and magnets.get_outside_state()
+                    and last_outside_crossing_prev == 0
+                    and motion_outside_crossing == 1
+                    and monotonic_time() > unlock_outside_tm + 0.2
+                ):
+                    fast_crossing = True
+                    logging.info("[BACKEND] Immediate lock after passage: outside motion detected after unlock (exit crossing).")
+                elif (
+                    motion_block_active
+                    and not exit_in_progress
+                    and unlock_inside_tm > 0.0
+                    and magnets.get_inside_state()
+                    and not inside_manually_unlocked
+                    and last_inside_crossing_prev == 0
+                    and motion_inside_crossing == 1
+                    and monotonic_time() > unlock_inside_tm + 0.2
+                ):
+                    fast_crossing = True
+                    logging.info("[BACKEND] Immediate lock after passage: inside motion detected after unlock (entry crossing).")
+
+                if fast_crossing:
+                    if first_motion_outside_mono <= 0.0 and motion_outside_crossing == 1:
+                        motion_block_id += 1
+                        first_motion_outside_tm = wall_time()
+                        first_motion_outside_mono = monotonic_time()
+                        if not any(e.get("action") == TimelineAction.MOTION_OUTSIDE for e in motion_timeline_entries):
+                            timeline_append(motion_timeline_entries, TimelineAction.MOTION_OUTSIDE)
+                    if first_motion_inside_mono <= 0.0 and motion_inside_crossing == 1:
+                        first_motion_inside_tm = wall_time()
+                        first_motion_inside_mono = monotonic_time()
+                        first_motion_inside_raw_tm = first_motion_inside_tm
+                        first_motion_inside_raw_mono = first_motion_inside_mono
+                    last_motion_outside_tm = wall_time()
+                    _finalize_motion_block("fast_in_out_crossing")
+
+            if last_inside == 0 and motion_inside == 1 and not suppress_inside_motion_block: # Inside motion detected
                 logging.info("[BACKEND] Motion detected INSIDE")
                 # For exit flows, inside motion can happen before outside motion.
                 # Start the timeline early so the order is logical in the UI.
@@ -1410,45 +1456,6 @@ def backend_main(simulate_kittyflap = False):
                 
                 manual_door_override['unlock_outside'] = False
 
-            if CONFIG.get('IMMEDIATE_LOCK_AFTER_PASSAGE'):
-                fast_crossing = False
-                if (
-                    motion_block_active
-                    and exit_in_progress
-                    and unlock_outside_tm > 0.0
-                    and magnets.get_outside_state()
-                    and last_outside_sensor_prev == 0
-                    and motion_outside_sensor == 1
-                    and monotonic_time() > unlock_outside_tm + 0.2
-                ):
-                    fast_crossing = True
-                    logging.info("[BACKEND] Immediate lock after passage: outside motion detected after unlock (exit crossing).")
-                elif (
-                    motion_block_active
-                    and not exit_in_progress
-                    and unlock_inside_tm > 0.0
-                    and magnets.get_inside_state()
-                    and not inside_manually_unlocked
-                    and last_inside_raw == 0
-                    and motion_inside_raw == 1
-                    and monotonic_time() > unlock_inside_tm + 0.2
-                ):
-                    fast_crossing = True
-                    logging.info("[BACKEND] Immediate lock after passage: inside motion detected after unlock (entry crossing).")
-
-                if fast_crossing:
-                    if first_motion_outside_mono <= 0.0 and motion_outside_sensor == 1:
-                        motion_block_id += 1
-                        first_motion_outside_tm = wall_time()
-                        first_motion_outside_mono = monotonic_time()
-                        if not any(e.get("action") == TimelineAction.MOTION_OUTSIDE for e in motion_timeline_entries):
-                            timeline_append(motion_timeline_entries, TimelineAction.MOTION_OUTSIDE)
-                    if first_motion_inside_raw_mono <= 0.0 and motion_inside_raw == 1:
-                        first_motion_inside_raw_tm = wall_time()
-                        first_motion_inside_raw_mono = monotonic_time()
-                    last_motion_outside_tm = wall_time()
-                    _finalize_motion_block("fast_in_out_crossing")
-
             if manual_door_override['lock_inside']:
                 if magnets.get_inside_state():
                     logging.info("[BACKEND] Manual override: Locking inside door")
@@ -1485,7 +1492,8 @@ def backend_main(simulate_kittyflap = False):
                 magnets.queue_command("lock_outside")
                 _timeline_log_outside_close()
 
-            last_outside_sensor = motion_outside_sensor
+            last_outside_crossing = motion_outside_crossing
+            last_inside_crossing = motion_inside_crossing
                 
         except Exception as e:
             # Log full traceback to identify the real call site in case of an exception in the backend loop

--- a/src/backend.py
+++ b/src/backend.py
@@ -425,6 +425,10 @@ def backend_main(simulate_kittyflap = False):
     timeline_outside_reported = None
     previous_use_camera_for_motion = None
     exit_in_progress = False
+    motion_block_active = False
+    suppress_outside_motion_block = False
+    last_outside_sensor = 0
+    motion_outside_sensor = 0
 
     # Register task in the sigterm_monitor object
     sigterm_monitor.register_task()
@@ -543,6 +547,7 @@ def backend_main(simulate_kittyflap = False):
         nonlocal timeline_video_cat_logged
         nonlocal timeline_rfid_cat_logged
         nonlocal timeline_outside_reported
+        nonlocal motion_block_active
 
         # Start a fresh verdict-info and timeline collection for this motion block.
         additional_verdict_infos = []
@@ -557,6 +562,160 @@ def backend_main(simulate_kittyflap = False):
             motion_timeline_entries,
             TimelineAction.MOTION_INSIDE if start_with_inside else TimelineAction.MOTION_OUTSIDE,
         )
+        motion_block_active = True
+
+    def _finalize_motion_block(trigger_source: str = "outside_motion_end"):
+        nonlocal unlock_inside_decision_made
+        nonlocal tag_id_valid
+        nonlocal additional_verdict_infos
+        nonlocal motion_timeline_entries
+        nonlocal first_motion_outside_tm
+        nonlocal first_motion_inside_tm
+        nonlocal first_motion_inside_raw_tm
+        nonlocal first_motion_outside_mono
+        nonlocal first_motion_inside_mono
+        nonlocal first_motion_inside_raw_mono
+        nonlocal last_motion_outside_tm
+        nonlocal tag_id_from_video
+        nonlocal exit_in_progress
+        nonlocal motion_block_active
+        nonlocal suppress_outside_motion_block
+        nonlocal unlock_inside_tm
+        nonlocal timeline_outside_reported
+
+        if not motion_block_active:
+            return
+
+        if trigger_source == "outside_motion_end":
+            timeline_append(motion_timeline_entries, TimelineAction.MOTION_OUTSIDE_END)
+        else:
+            timeline_append(motion_timeline_entries, TimelineAction.FAST_IN_OUT_CROSSING)
+
+        exit_in_progress = False
+        unlock_inside_decision_made = False
+        tag_id_valid = False
+
+        if trigger_source == "fast_in_out_crossing":
+            if magnets.get_inside_state() and magnets.check_queued("lock_inside") == False and inside_manually_unlocked == False:
+                magnets.queue_command("lock_inside")
+                unlock_inside_tm = 0.0
+                _timeline_log_inside_close(TimelineAction.INSIDE_CLOSED_FAST_IN_OUT)
+            if magnets.get_outside_state() and magnets.check_queued("lock_outside") == False:
+                if timeline_outside_reported != "closed":
+                    timeline_outside_reported = "closed"
+                    timeline_append(motion_timeline_entries, TimelineAction.OUTSIDE_CLOSED_FAST_IN_OUT)
+                magnets.queue_command("lock_outside")
+            suppress_outside_motion_block = True
+        elif (
+            magnets.get_inside_state() == True
+            and magnets.check_queued("lock_inside") == False
+            and inside_manually_unlocked == False
+        ):
+            magnets.queue_command("lock_inside")
+            _timeline_log_inside_close(TimelineAction.INSIDE_CLOSED_MOTION_END)
+
+        if first_motion_inside_raw_mono == 0.0 or (first_motion_outside_mono - first_motion_inside_raw_mono) > 60.0:
+            if unlock_inside_tm > first_motion_outside_mono and tag_id is not None:
+                logging.info("[BACKEND] Motion event conclusion: No motion inside detected but the inside was unlocked. Cat went probably to the inside (PIR interference issue).")
+                event_type = EventType.CAT_WENT_PROBABLY_INSIDE
+            elif mouse_check_conditions["no_mouse_detected"]:
+                logging.info("[BACKEND] Motion event conclusion: No one went inside.")
+                event_type = EventType.MOTION_OUTSIDE_ONLY
+            else:
+                logging.info("[BACKEND] Motion event conclusion: Motion outside with mouse detected and entry blocked.")
+                event_type = EventType.MOTION_OUTSIDE_WITH_MOUSE
+        elif first_motion_outside_mono < first_motion_inside_raw_mono:
+            if mouse_check_conditions["no_mouse_detected"]:
+                logging.info("[BACKEND] Motion event conclusion: Cat went inside.")
+                event_type = EventType.CAT_WENT_INSIDE
+            else:
+                logging.info("[BACKEND] Motion event conclusion: Cat went inside with mouse detected.")
+                event_type = EventType.CAT_WENT_INSIDE_WITH_MOUSE
+        else:
+            logging.info("[BACKEND] Motion event conclusion: Cat went outside.")
+            event_type = EventType.CAT_WENT_OUTSIDE
+
+        timeline_append(
+            motion_timeline_entries,
+            TimelineAction.EVENT_CONCLUSION,
+            conclusion=str(event_type),
+        )
+
+        if use_camera_for_motion:
+            if event_type == EventType.CAT_WENT_OUTSIDE:
+                log_start_tm = min(first_motion_outside_tm, first_motion_inside_tm + 2.5)
+            else:
+                log_start_tm = first_motion_outside_tm - 2.5
+        else:
+            log_start_tm = first_motion_outside_tm if first_motion_outside_tm > 0.0 else first_motion_inside_raw_tm
+
+        if trigger_source == "fast_in_out_crossing" and last_motion_outside_tm <= 0.0:
+            last_motion_outside_tm = wall_time()
+
+        all_events = str(event_type)
+        if additional_verdict_infos:
+            for info in additional_verdict_infos:
+                all_events += "," + str(info)
+        additional_verdict_infos = []
+
+        img_ids_for_motion_block = image_buffer.get_filtered_ids(log_start_tm, last_motion_outside_tm)
+        ids_exceeding_mouse_th = image_buffer.get_filtered_ids(log_start_tm, last_motion_outside_tm, min_mouse_probability=CONFIG['MIN_THRESHOLD'])
+        ids_exceeding_nomouse_th = image_buffer.get_filtered_ids(log_start_tm, last_motion_outside_tm, min_no_mouse_probability=CONFIG['MIN_THRESHOLD'])
+        ids_exceeding_own_cat_th = image_buffer.get_filtered_ids(log_start_tm, last_motion_outside_tm, min_own_cat_probability=CONFIG['MIN_THRESHOLD'])
+        logging.info(f"""[BACKEND] {motion_source}-based motion detection: Detection summary ({trigger_source}):
+                                                            - {len(img_ids_for_motion_block)} elements in current motion block (between {first_motion_outside_tm} and {last_motion_outside_tm})
+                                                            - {len(ids_exceeding_mouse_th)} elements where "mouse" detection exceeded the min. logging threshold of {CONFIG['MIN_THRESHOLD']}
+                                                            - {len(ids_exceeding_nomouse_th)} elements where "no-mouse" detection exceeded the min. logging threshold of {CONFIG['MIN_THRESHOLD']}
+                                                            - {len(ids_exceeding_own_cat_th)} elements where "own cat" detection exceeded the min. logging threshold of {CONFIG['MIN_THRESHOLD']}
+                                                            Event type: {all_events}
+                                                            RFID tag: {tag_id or 'None'} 
+                                                            Video tag: {tag_id_from_video or 'None'}""")
+        if ((len(ids_exceeding_mouse_th) + len(ids_exceeding_nomouse_th) + len(ids_exceeding_own_cat_th) > 0) or
+            (event_type in [EventType.CAT_WENT_OUTSIDE]) or
+            (tag_id is not None) or
+            (tag_id_from_video is not None)):
+            for element in img_ids_for_motion_block:
+                image_buffer.update_block_id(element, motion_block_id)
+                if tag_id is not None:
+                    image_buffer.update_tag_id(element, tag_id)
+                elif tag_id_from_video is not None:
+                    image_buffer.update_tag_id(element, tag_id_from_video)
+            logging.info(f"[BACKEND] Minimal threshold exceeded or tag ID detected. Images will be written to the database. Updated block ID for {len(img_ids_for_motion_block)} elements to '{motion_block_id}' and tag ID to '{tag_id if tag_id is not None else ''}'")
+            timeline_snapshot = list(motion_timeline_entries)
+            db_thread = threading.Thread(
+                target=write_motion_block_to_db,
+                args=(CONFIG['KITTYHACK_DATABASE_PATH'], motion_block_id, all_events),
+                kwargs={"timeline_entries": timeline_snapshot},
+                daemon=True,
+            )
+            db_thread.start()
+        else:
+            logging.info(f"[BACKEND] No elements found that exceed the minimal threshold '{CONFIG['MIN_THRESHOLD']}' and no tag ID was detected. No database entry will be created.")
+            if len(img_ids_for_motion_block) > 0:
+                for element in img_ids_for_motion_block:
+                    image_buffer.delete_by_id(element)
+
+        first_motion_outside_tm = 0.0
+        first_motion_inside_tm = 0.0
+        first_motion_inside_raw_tm = 0.0
+        first_motion_outside_mono = 0.0
+        first_motion_inside_mono = 0.0
+        first_motion_inside_raw_mono = 0.0
+        motion_block_active = False
+
+        if mqtt_publisher:
+            if tag_id is not None:
+                cat_name = get_cat_name(tag_id)
+            else:
+                cat_name = get_cat_name(tag_id_from_video)
+            mqtt_publisher.publish_event_type(all_events, cat_name)
+            mqtt_publisher.publish_motion_outside(False)
+
+        tag_id_from_video = None
+        motion_timeline_entries = []
+        if tag_id is not None:
+            rfid.set_tag(None, 0.0)
+            logging.info("[BACKEND] Forget the tag ID from the RFID reader.")
 
     # Periodically persist effective FPS into the active YOLO model metadata.
     last_fps_metadata_write_mono = 0.0
@@ -670,6 +829,7 @@ def backend_main(simulate_kittyflap = False):
             last_outside = motion_outside
             last_inside = motion_inside
             last_inside_raw = motion_inside_raw
+            last_outside_sensor_prev = last_outside_sensor
 
             if use_camera_for_motion:
                 # Decide if motion occured currently. Look up to 5 seconds into the past for images with cats
@@ -681,6 +841,11 @@ def backend_main(simulate_kittyflap = False):
                 __, motion_inside, __, motion_inside_raw = pir.get_states()
             else:
                 motion_outside, motion_inside, motion_outside_raw, motion_inside_raw = pir.get_states()
+
+            if use_camera_for_motion:
+                motion_outside_sensor = motion_outside
+            else:
+                motion_outside_sensor = motion_outside_raw
 
             # Update the motion timestamps
             if motion_outside == 1:
@@ -722,137 +887,19 @@ def backend_main(simulate_kittyflap = False):
                 rfid_thread.start()
 
             # Outside motion stopped
+            if suppress_outside_motion_block and motion_outside == 0 and motion_outside_sensor == 0:
+                suppress_outside_motion_block = False
+
             if last_outside == 1 and motion_outside == 0:
                 if not use_camera_for_motion:
                     if model_handler.get_run_state() == True:
                         model_handler.pause()
                         # Wait for the last image to be processed
                         tm.sleep(0.5)
-                unlock_inside_decision_made = False
-                tag_id_valid = False
                 last_motion_outside_tm = wall_time()
                 last_motion_outside_mono = monotonic_time()
                 logging.info(f"[BACKEND] {motion_source}-based motion detection: Motion stopped OUTSIDE (Block ID: '{motion_block_id}')")
-                timeline_append(motion_timeline_entries, TimelineAction.MOTION_OUTSIDE_END)
-                # Reset exit flag on block end
-                exit_in_progress = False
-                if (magnets.get_inside_state() == True and magnets.check_queued("lock_inside") == False and inside_manually_unlocked == False):
-                    magnets.queue_command("lock_inside")
-                    _timeline_log_inside_close(TimelineAction.INSIDE_CLOSED_MOTION_END)
-
-                # Decide if the cat went in or out:
-                if first_motion_inside_raw_mono == 0.0 or (first_motion_outside_mono - first_motion_inside_raw_mono) > 60.0:
-                    if unlock_inside_tm > first_motion_outside_mono and tag_id is not None:
-                        logging.info("[BACKEND] Motion event conclusion: No motion inside detected but the inside was unlocked. Cat went probably to the inside (PIR interference issue).")
-                        event_type = EventType.CAT_WENT_PROBABLY_INSIDE
-                    elif mouse_check_conditions["no_mouse_detected"]:
-                        logging.info("[BACKEND] Motion event conclusion: No one went inside.")
-                        event_type = EventType.MOTION_OUTSIDE_ONLY
-                    else:
-                        logging.info("[BACKEND] Motion event conclusion: Motion outside with mouse detected and entry blocked.")
-                        event_type = EventType.MOTION_OUTSIDE_WITH_MOUSE
-                elif first_motion_outside_mono < first_motion_inside_raw_mono:
-                    if mouse_check_conditions["no_mouse_detected"]:
-                        logging.info("[BACKEND] Motion event conclusion: Cat went inside.")
-                        event_type = EventType.CAT_WENT_INSIDE
-                    else:
-                        logging.info("[BACKEND] Motion event conclusion: Cat went inside with mouse detected.")
-                        event_type = EventType.CAT_WENT_INSIDE_WITH_MOUSE
-                else:
-                    logging.info("[BACKEND] Motion event conclusion: Cat went outside.")
-                    event_type = EventType.CAT_WENT_OUTSIDE
-
-                timeline_append(
-                    motion_timeline_entries,
-                    TimelineAction.EVENT_CONCLUSION,
-                    conclusion=str(event_type),
-                )
-
-                if use_camera_for_motion:
-                    if event_type == EventType.CAT_WENT_OUTSIDE:
-                        # Use either the first_motion_outside_tm or the first_motion_inside_tm+2.5, whichever is earlier, as the timestamp for the event
-                        log_start_tm = min(first_motion_outside_tm, first_motion_inside_tm + 2.5)
-                    else:
-                        # Log 2.5 seconds earlier, since the camera might not detect the cat immediately
-                        log_start_tm = first_motion_outside_tm - 2.5
-                else:
-                    # Don't log earlier than the first motion outside timestamp when using PIR-based motion detection
-                    log_start_tm = first_motion_outside_tm
-
-
-                all_events = str(event_type)
-                # Add all additional verdict information to the event type
-                if additional_verdict_infos:
-                    for info in additional_verdict_infos:
-                        all_events += "," + str(info)
-                additional_verdict_infos = []
-
-                # Update the motion_block_id and the tag_id for for all elements between log_start_tm and last_motion_outside_tm
-                img_ids_for_motion_block = image_buffer.get_filtered_ids(log_start_tm, last_motion_outside_tm)
-                ids_exceeding_mouse_th = image_buffer.get_filtered_ids(log_start_tm, last_motion_outside_tm, min_mouse_probability=CONFIG['MIN_THRESHOLD'])
-                ids_exceeding_nomouse_th = image_buffer.get_filtered_ids(log_start_tm, last_motion_outside_tm, min_no_mouse_probability=CONFIG['MIN_THRESHOLD'])
-                ids_exceeding_own_cat_th = image_buffer.get_filtered_ids(log_start_tm, last_motion_outside_tm, min_own_cat_probability=CONFIG['MIN_THRESHOLD'])
-                logging.info(f"""[BACKEND] {motion_source}-based motion detection: Detection summary:
-                                                            - {len(img_ids_for_motion_block)} elements in current motion block (between {first_motion_outside_tm} and {last_motion_outside_tm})
-                                                            - {len(ids_exceeding_mouse_th)} elements where "mouse" detection exceeded the min. logging threshold of {CONFIG['MIN_THRESHOLD']}
-                                                            - {len(ids_exceeding_nomouse_th)} elements where "no-mouse" detection exceeded the min. logging threshold of {CONFIG['MIN_THRESHOLD']}
-                                                            - {len(ids_exceeding_own_cat_th)} elements where "own cat" detection exceeded the min. logging threshold of {CONFIG['MIN_THRESHOLD']}
-                                                            Event type: {all_events}
-                                                            RFID tag: {tag_id or 'None'} 
-                                                            Video tag: {tag_id_from_video or 'None'}""")
-                # Log all events to the database, where either the mouse threshold is exceeded, the no-mouse threshold is exceeded,
-                # or the own cat threshold is exceeded or a tag id was detected
-                # as well as all outgoing events
-                if ((len(ids_exceeding_mouse_th) + len(ids_exceeding_nomouse_th) +len(ids_exceeding_own_cat_th) > 0) or 
-                    (event_type in [EventType.CAT_WENT_OUTSIDE]) or 
-                    (tag_id is not None) or 
-                    (tag_id_from_video is not None)):
-                    for element in img_ids_for_motion_block:
-                        image_buffer.update_block_id(element, motion_block_id)
-                        # Prefer the tag_id from the RFID reader. If this is not available, fall back to the detected id from the video
-                        if tag_id is not None:
-                            image_buffer.update_tag_id(element, tag_id)
-                        elif tag_id_from_video is not None:
-                            image_buffer.update_tag_id(element, tag_id_from_video)
-                    logging.info(f"[BACKEND] Minimal threshold exceeded or tag ID detected. Images will be written to the database. Updated block ID for {len(img_ids_for_motion_block)} elements to '{motion_block_id}' and tag ID to '{tag_id if tag_id is not None else ''}'")
-                    timeline_snapshot = list(motion_timeline_entries)
-                    db_thread = threading.Thread(
-                        target=write_motion_block_to_db,
-                        args=(CONFIG['KITTYHACK_DATABASE_PATH'], motion_block_id, all_events),
-                        kwargs={"timeline_entries": timeline_snapshot},
-                        daemon=True,
-                    )
-                    db_thread.start()
-                else:
-                    logging.info(f"[BACKEND] No elements found that exceed the minimal threshold '{CONFIG['MIN_THRESHOLD']}' and no tag ID was detected. No database entry will be created.")
-                    if len(img_ids_for_motion_block) > 0:
-                        for element in img_ids_for_motion_block:
-                            image_buffer.delete_by_id(element)
-                
-                # Reset the first motion timestamps
-                first_motion_outside_tm = 0.0
-                first_motion_inside_tm = 0.0
-                first_motion_inside_raw_tm = 0.0
-                first_motion_outside_mono = 0.0
-                first_motion_inside_mono = 0.0
-                first_motion_inside_raw_mono = 0.0
-
-                # Publish the event to MQTT
-                if mqtt_publisher:
-                    if tag_id is not None:
-                        cat_name = get_cat_name(tag_id)
-                    else:
-                        cat_name = get_cat_name(tag_id_from_video)
-                    mqtt_publisher.publish_event_type(all_events, cat_name)
-                    mqtt_publisher.publish_motion_outside(False)
-
-                # Forget the video tag id
-                tag_id_from_video = None
-                # The current event is finished. Start the next event with a fresh timeline.
-                motion_timeline_entries = []
-                if tag_id is not None:
-                    rfid.set_tag(None, 0.0)
-                    logging.info("[BACKEND] Forget the tag ID from the RFID reader.")
+                _finalize_motion_block("outside_motion_end")
 
             if last_inside_raw == 1 and motion_inside_raw == 0: # Inside motion stopped (raw)
                 last_motion_inside_raw_mono = motion_inside_raw_mono
@@ -873,7 +920,7 @@ def backend_main(simulate_kittyflap = False):
                     logging.info(f"[BACKEND] Enabled RFID field.")
             
             # Outside motion detected
-            if last_outside == 0 and motion_outside == 1:
+            if last_outside == 0 and motion_outside == 1 and not suppress_outside_motion_block:
                 motion_block_id += 1
                 # If this block was already started by an inside-motion trigger,
                 # keep the collected timeline and only append the outside motion step.
@@ -1363,6 +1410,45 @@ def backend_main(simulate_kittyflap = False):
                 
                 manual_door_override['unlock_outside'] = False
 
+            if CONFIG.get('IMMEDIATE_LOCK_AFTER_PASSAGE'):
+                fast_crossing = False
+                if (
+                    motion_block_active
+                    and exit_in_progress
+                    and unlock_outside_tm > 0.0
+                    and magnets.get_outside_state()
+                    and last_outside_sensor_prev == 0
+                    and motion_outside_sensor == 1
+                    and monotonic_time() > unlock_outside_tm + 0.2
+                ):
+                    fast_crossing = True
+                    logging.info("[BACKEND] Immediate lock after passage: outside motion detected after unlock (exit crossing).")
+                elif (
+                    motion_block_active
+                    and not exit_in_progress
+                    and unlock_inside_tm > 0.0
+                    and magnets.get_inside_state()
+                    and not inside_manually_unlocked
+                    and last_inside_raw == 0
+                    and motion_inside_raw == 1
+                    and monotonic_time() > unlock_inside_tm + 0.2
+                ):
+                    fast_crossing = True
+                    logging.info("[BACKEND] Immediate lock after passage: inside motion detected after unlock (entry crossing).")
+
+                if fast_crossing:
+                    if first_motion_outside_mono <= 0.0 and motion_outside_sensor == 1:
+                        motion_block_id += 1
+                        first_motion_outside_tm = wall_time()
+                        first_motion_outside_mono = monotonic_time()
+                        if not any(e.get("action") == TimelineAction.MOTION_OUTSIDE for e in motion_timeline_entries):
+                            timeline_append(motion_timeline_entries, TimelineAction.MOTION_OUTSIDE)
+                    if first_motion_inside_raw_mono <= 0.0 and motion_inside_raw == 1:
+                        first_motion_inside_raw_tm = wall_time()
+                        first_motion_inside_raw_mono = monotonic_time()
+                    last_motion_outside_tm = wall_time()
+                    _finalize_motion_block("fast_in_out_crossing")
+
             if manual_door_override['lock_inside']:
                 if magnets.get_inside_state():
                     logging.info("[BACKEND] Manual override: Locking inside door")
@@ -1398,6 +1484,8 @@ def backend_main(simulate_kittyflap = False):
                 logging.warning("[BACKEND] Maximum unlock time exceeded for outside door. Forcing lock.")
                 magnets.queue_command("lock_outside")
                 _timeline_log_outside_close()
+
+            last_outside_sensor = motion_outside_sensor
                 
         except Exception as e:
             # Log full traceback to identify the real call site in case of an exception in the backend loop

--- a/src/backend.py
+++ b/src/backend.py
@@ -433,6 +433,7 @@ def backend_main(simulate_kittyflap = False):
     suppress_entry_decision_after_fast_exit = False
     last_outside_crossing = 0
     last_inside_crossing = 0
+    last_inside_raw_crossing = 0
     pending_fast_exit_finalize_mono = 0.0
     # Immediate-lock-after-passage state:
     #   entry_unlocked_in_block  -> an entry was granted (inside auto-unlocked) during the current motion block
@@ -886,6 +887,7 @@ def backend_main(simulate_kittyflap = False):
             last_inside_raw = motion_inside_raw
             last_outside_crossing_prev = last_outside_crossing
             last_inside_crossing_prev = last_inside_crossing
+            last_inside_raw_crossing_prev = last_inside_raw_crossing
 
             if use_camera_for_motion:
                 # Decide if motion occured currently. Look up to 5 seconds into the past for images with cats
@@ -901,6 +903,10 @@ def backend_main(simulate_kittyflap = False):
             # Threshold-filtered motion (not raw PIR) for immediate-lock crossing detection.
             motion_outside_crossing = motion_outside
             motion_inside_crossing = motion_inside
+            # Raw inside PIR (pre-lazy, pre-threshold) is additionally tracked for entry crossings:
+            # very fast cats can trigger the inside PIR too briefly to pass the threshold filter, so
+            # relying on the filtered signal alone would miss them.
+            motion_inside_raw_crossing = motion_inside_raw
 
             # Update the motion timestamps
             if motion_outside == 1:
@@ -1027,8 +1033,9 @@ def backend_main(simulate_kittyflap = False):
                 first_motion_inside_raw_mono = monotonic_time()
 
             # Immediate lock after passage: detect that the cat has crossed to the other side of the
-            # flap and lock + finalize the event right away. Crossing detection uses the threshold-
-            # filtered PIR signals (motion_*_crossing), never the raw PIR, to avoid ghost triggers.
+            # flap and lock + finalize the event right away. The exit crossing uses the threshold-
+            # filtered PIR/camera signal to avoid ghost triggers; the entry crossing additionally
+            # accepts the raw inside PIR so very fast cats are not missed.
             if CONFIG.get('IMMEDIATE_LOCK_AFTER_PASSAGE') and not _motion_processing_suspended():
                 # Exit passage: outside motion appears while an exit is in progress and the outside is unlocked.
                 fast_exit_crossing = (
@@ -1044,13 +1051,19 @@ def backend_main(simulate_kittyflap = False):
                 # This intentionally does NOT require the inside to still be unlocked, so that a late
                 # (often false-positive) prey re-lock cannot turn the cat finishing its entry into a
                 # spurious exit. entry_unlocked_mono is the debounce reference and survives the re-lock.
+                # We accept a rising edge on EITHER the filtered inside PIR OR the raw inside PIR: for
+                # very fast cats the inside motion is often too brief to pass the threshold filter, so
+                # the raw signal is required to not miss the passage.
+                inside_crossing_rising = (
+                    (last_inside_crossing_prev == 0 and motion_inside_crossing == 1)
+                    or (last_inside_raw_crossing_prev == 0 and motion_inside_raw_crossing == 1)
+                )
                 fast_entry_crossing = (
                     motion_block_active
                     and not exit_in_progress
                     and entry_unlocked_in_block
                     and not inside_manually_unlocked
-                    and last_inside_crossing_prev == 0
-                    and motion_inside_crossing == 1
+                    and inside_crossing_rising
                     and monotonic_time() > entry_unlocked_mono + 0.2
                 )
 
@@ -1068,7 +1081,7 @@ def backend_main(simulate_kittyflap = False):
                         first_motion_outside_mono = monotonic_time()
                         if not any(e.get("action") == TimelineAction.MOTION_OUTSIDE for e in motion_timeline_entries):
                             timeline_append(motion_timeline_entries, TimelineAction.MOTION_OUTSIDE)
-                    if first_motion_inside_mono <= 0.0 and motion_inside_crossing == 1:
+                    if first_motion_inside_mono <= 0.0 and (motion_inside_crossing == 1 or motion_inside_raw_crossing == 1):
                         first_motion_inside_tm = wall_time()
                         first_motion_inside_mono = monotonic_time()
                         first_motion_inside_raw_tm = first_motion_inside_tm
@@ -1592,6 +1605,7 @@ def backend_main(simulate_kittyflap = False):
 
             last_outside_crossing = motion_outside_crossing
             last_inside_crossing = motion_inside_crossing
+            last_inside_raw_crossing = motion_inside_raw_crossing
                 
         except Exception as e:
             # Log full traceback to identify the real call site in case of an exception in the backend loop

--- a/src/backend.py
+++ b/src/backend.py
@@ -27,6 +27,7 @@ MAX_UNLOCK_TIME = 60.0           # Maximum time the door is allowed to stay open
 LAZY_CAT_DELAY_PIR_MOTION = 6.0  # Keep the PIR active for an additional 6 seconds after the last detected motion when using PIR-based motion detection
 LAZY_CAT_DELAY_CAM_MOTION = 12.0 # Keep the PIR active for an additional 12 seconds after the last detected motion when using camera-based motion detection
 FAST_EXIT_POST_CAPTURE_SECONDS = 6.0  # Extra recording after fast-lock exit crossing before finalizing the event
+EVENT_COOLDOWN_SECONDS = 3.0     # After an event is finalized, ignore all new motion triggers for this long (PIR settling)
 
 # Prepare gettext for translations based on the configured language
 _ = set_language(CONFIG['LANGUAGE'])
@@ -433,6 +434,13 @@ def backend_main(simulate_kittyflap = False):
     last_outside_crossing = 0
     last_inside_crossing = 0
     pending_fast_exit_finalize_mono = 0.0
+    # Immediate-lock-after-passage state:
+    #   entry_unlocked_in_block  -> an entry was granted (inside auto-unlocked) during the current motion block
+    #   entry_unlocked_mono      -> monotonic time of that entry unlock (debounce reference, survives prey re-lock)
+    #   event_cooldown_until_mono-> while now < this value, no new motion triggers are accepted (PIR settling)
+    entry_unlocked_in_block = False
+    entry_unlocked_mono = 0.0
+    event_cooldown_until_mono = 0.0
 
     # Register task in the sigterm_monitor object
     sigterm_monitor.register_task()
@@ -611,6 +619,10 @@ def backend_main(simulate_kittyflap = False):
         nonlocal unlock_inside_tm
         nonlocal timeline_outside_reported
         nonlocal pending_fast_exit_finalize_mono
+        nonlocal entry_unlocked_in_block
+        nonlocal entry_unlocked_mono
+        nonlocal event_cooldown_until_mono
+        nonlocal pending_exit_rfid_check
 
         if not motion_block_active:
             return
@@ -619,8 +631,8 @@ def backend_main(simulate_kittyflap = False):
 
         if trigger_source == "outside_motion_end":
             timeline_append(motion_timeline_entries, TimelineAction.MOTION_OUTSIDE_END)
-        elif not locks_already_applied:
-            timeline_append(motion_timeline_entries, TimelineAction.FAST_IN_OUT_CROSSING)
+        # Note: the "Cat crossed the flap" (FAST_IN_OUT_CROSSING) timeline entry is added exactly
+        # once by _apply_fast_crossing_locks(), which is the single source for fast-crossing locks.
 
         exit_in_progress = False
         unlock_inside_decision_made = False
@@ -725,6 +737,14 @@ def backend_main(simulate_kittyflap = False):
         first_motion_inside_raw_mono = 0.0
         motion_block_active = False
 
+        # Reset per-block passage state and start the post-event cooldown so that trailing PIR
+        # motion (cat settling on the other side, sensor ghosting) cannot spawn a phantom event.
+        entry_unlocked_in_block = False
+        entry_unlocked_mono = 0.0
+        pending_exit_rfid_check = False
+        if CONFIG.get('IMMEDIATE_LOCK_AFTER_PASSAGE'):
+            event_cooldown_until_mono = monotonic_time() + EVENT_COOLDOWN_SECONDS
+
         if mqtt_publisher:
             if tag_id is not None:
                 cat_name = get_cat_name(tag_id)
@@ -738,6 +758,19 @@ def backend_main(simulate_kittyflap = False):
         if tag_id is not None:
             rfid.set_tag(None, 0.0)
             logging.info("[BACKEND] Forget the tag ID from the RFID reader.")
+
+    def _motion_processing_suspended() -> bool:
+        """While True, the backend must ignore every new motion trigger (new motion blocks,
+        entry/exit unlocks and fast-crossing detection).
+
+        This is active in two situations, both only relevant when IMMEDIATE_LOCK_AFTER_PASSAGE is on:
+          1. During the fast-exit post-capture window (flap already locked, still recording).
+          2. During the post-event cooldown right after an event was finalized (PIR settling)."""
+        if pending_fast_exit_finalize_mono > 0.0:
+            return True
+        if event_cooldown_until_mono > 0.0 and monotonic_time() < event_cooldown_until_mono:
+            return True
+        return False
 
     # Periodically persist effective FPS into the active YOLO model metadata.
     last_fps_metadata_write_mono = 0.0
@@ -962,7 +995,7 @@ def backend_main(simulate_kittyflap = False):
                     logging.info(f"[BACKEND] Enabled RFID field.")
             
             # Outside motion detected
-            if last_outside == 0 and motion_outside == 1 and not suppress_outside_motion_block:
+            if last_outside == 0 and motion_outside == 1 and not suppress_outside_motion_block and not _motion_processing_suspended():
                 motion_block_id += 1
                 # If this block was already started by an inside-motion trigger,
                 # keep the collected timeline and only append the outside motion step.
@@ -993,9 +1026,12 @@ def backend_main(simulate_kittyflap = False):
                 first_motion_inside_raw_tm = wall_time()
                 first_motion_inside_raw_mono = monotonic_time()
 
-            if CONFIG.get('IMMEDIATE_LOCK_AFTER_PASSAGE'):
-                fast_crossing = False
-                if (
+            # Immediate lock after passage: detect that the cat has crossed to the other side of the
+            # flap and lock + finalize the event right away. Crossing detection uses the threshold-
+            # filtered PIR signals (motion_*_crossing), never the raw PIR, to avoid ghost triggers.
+            if CONFIG.get('IMMEDIATE_LOCK_AFTER_PASSAGE') and not _motion_processing_suspended():
+                # Exit passage: outside motion appears while an exit is in progress and the outside is unlocked.
+                fast_exit_crossing = (
                     motion_block_active
                     and exit_in_progress
                     and unlock_outside_tm > 0.0
@@ -1003,23 +1039,29 @@ def backend_main(simulate_kittyflap = False):
                     and last_outside_crossing_prev == 0
                     and motion_outside_crossing == 1
                     and monotonic_time() > unlock_outside_tm + 0.2
-                ):
-                    fast_crossing = True
-                    logging.info("[BACKEND] Immediate lock after passage: outside motion detected after unlock (exit crossing).")
-                elif (
+                )
+                # Entry passage: inside motion appears after an entry was granted in this block.
+                # This intentionally does NOT require the inside to still be unlocked, so that a late
+                # (often false-positive) prey re-lock cannot turn the cat finishing its entry into a
+                # spurious exit. entry_unlocked_mono is the debounce reference and survives the re-lock.
+                fast_entry_crossing = (
                     motion_block_active
                     and not exit_in_progress
-                    and unlock_inside_tm > 0.0
-                    and magnets.get_inside_state()
+                    and entry_unlocked_in_block
                     and not inside_manually_unlocked
                     and last_inside_crossing_prev == 0
                     and motion_inside_crossing == 1
-                    and monotonic_time() > unlock_inside_tm + 0.2
-                ):
-                    fast_crossing = True
-                    logging.info("[BACKEND] Immediate lock after passage: inside motion detected after unlock (entry crossing).")
+                    and monotonic_time() > entry_unlocked_mono + 0.2
+                )
 
-                if fast_crossing:
+                if fast_exit_crossing or fast_entry_crossing:
+                    if fast_exit_crossing:
+                        logging.info("[BACKEND] Immediate lock after passage: outside motion detected after unlock (exit crossing).")
+                    else:
+                        logging.info("[BACKEND] Immediate lock after passage: inside motion detected after unlock (entry crossing).")
+
+                    # Make sure both motion timestamps exist so the event conclusion and the image
+                    # capture window are computed correctly.
                     if first_motion_outside_mono <= 0.0 and motion_outside_crossing == 1:
                         motion_block_id += 1
                         first_motion_outside_tm = wall_time()
@@ -1032,17 +1074,24 @@ def backend_main(simulate_kittyflap = False):
                         first_motion_inside_raw_tm = first_motion_inside_tm
                         first_motion_inside_raw_mono = first_motion_inside_mono
                     last_motion_outside_tm = wall_time()
-                    if exit_in_progress:
-                        _apply_fast_crossing_locks()
+
+                    # Lock the flap immediately. This is the single source of the "Cat crossed the flap"
+                    # timeline entry and of the suppression flags.
+                    _apply_fast_crossing_locks()
+
+                    if fast_exit_crossing:
+                        # Keep recording for a short while so the outside camera captures the cat that
+                        # just left, then finalize. The post-capture window also blocks every new
+                        # trigger via _motion_processing_suspended().
                         pending_fast_exit_finalize_mono = monotonic_time() + FAST_EXIT_POST_CAPTURE_SECONDS
                         logging.info(
                             "[BACKEND] Immediate lock after exit passage: flap locked, "
                             f"continuing capture for {FAST_EXIT_POST_CAPTURE_SECONDS:.1f}s before finalizing event."
                         )
                     else:
-                        _finalize_motion_block("fast_in_out_crossing")
+                        _finalize_motion_block("fast_in_out_crossing", locks_already_applied=True)
 
-            if last_inside == 0 and motion_inside == 1 and not suppress_inside_motion_block: # Inside motion detected
+            if last_inside == 0 and motion_inside == 1 and not suppress_inside_motion_block and not _motion_processing_suspended(): # Inside motion detected
                 logging.info("[BACKEND] Motion detected INSIDE")
                 # For exit flows, inside motion can happen before outside motion.
                 # Start the timeline early so the order is logical in the UI.
@@ -1227,7 +1276,7 @@ def backend_main(simulate_kittyflap = False):
                         )
 
             # Handle pending per-cat exit decision while inside motion remains active
-            if pending_exit_rfid_check:
+            if pending_exit_rfid_check and not _motion_processing_suspended():
                 if motion_inside == 0:
                     pending_exit_rfid_check = False
                     logging.info("[BACKEND] Inside motion ended before RFID tag was detected; outside will remain locked.")
@@ -1466,7 +1515,7 @@ def backend_main(simulate_kittyflap = False):
                     unlock_inside_tm = 0.0
                     _timeline_log_inside_close(TimelineAction.INSIDE_CLOSED_PREY)
 
-            if unlock_inside or manual_door_override['unlock_inside']:
+            if (unlock_inside and not _motion_processing_suspended()) or manual_door_override['unlock_inside']:
                 logging.info(f"[BACKEND] Door unlock requested {'(manual override)' if manual_door_override['unlock_inside'] else ''}")
                 logging.debug(f"[BACKEND] Motion outside: {motion_outside}, Motion inside: {motion_inside}, Tag ID: {tag_id}, Tag valid: {tag_id_valid}, Motion block ID: {motion_block_id}, Images with mouse: {len(ids_with_mouse)}, Images in current block: {len(ids_of_current_motion_block)} ({ids_of_current_motion_block})")
                 if manual_door_override['unlock_inside'] and magnets.get_inside_state():
@@ -1486,6 +1535,10 @@ def backend_main(simulate_kittyflap = False):
                                 logging.info(f"[BACKEND] Added verdict info '{flag}' due to manual inside unlock.")
                     else:
                         inside_manually_unlocked = False
+                        # Remember that an entry was granted in this block. Used by the immediate-lock
+                        # entry-passage detection so the cat finishing its entry is not mistaken for an exit.
+                        entry_unlocked_in_block = True
+                        entry_unlocked_mono = monotonic_time()
                 
                 manual_door_override['unlock_inside'] = False
 

--- a/src/backend.py
+++ b/src/backend.py
@@ -26,6 +26,7 @@ OPEN_OUTSIDE_TIMEOUT = 6.0 + CONFIG['PIR_INSIDE_THRESHOLD'] # Keep the magnet to
 MAX_UNLOCK_TIME = 60.0           # Maximum time the door is allowed to stay open
 LAZY_CAT_DELAY_PIR_MOTION = 6.0  # Keep the PIR active for an additional 6 seconds after the last detected motion when using PIR-based motion detection
 LAZY_CAT_DELAY_CAM_MOTION = 12.0 # Keep the PIR active for an additional 12 seconds after the last detected motion when using camera-based motion detection
+FAST_EXIT_POST_CAPTURE_SECONDS = 6.0  # Extra recording after fast-lock exit crossing before finalizing the event
 
 # Prepare gettext for translations based on the configured language
 _ = set_language(CONFIG['LANGUAGE'])
@@ -428,8 +429,10 @@ def backend_main(simulate_kittyflap = False):
     motion_block_active = False
     suppress_outside_motion_block = False
     suppress_inside_motion_block = False
+    suppress_entry_decision_after_fast_exit = False
     last_outside_crossing = 0
     last_inside_crossing = 0
+    pending_fast_exit_finalize_mono = 0.0
 
     # Register task in the sigterm_monitor object
     sigterm_monitor.register_task()
@@ -565,7 +568,29 @@ def backend_main(simulate_kittyflap = False):
         )
         motion_block_active = True
 
-    def _finalize_motion_block(trigger_source: str = "outside_motion_end"):
+    def _apply_fast_crossing_locks():
+        nonlocal exit_in_progress
+        nonlocal suppress_outside_motion_block
+        nonlocal suppress_inside_motion_block
+        nonlocal suppress_entry_decision_after_fast_exit
+        nonlocal unlock_inside_tm
+        nonlocal timeline_outside_reported
+
+        timeline_append(motion_timeline_entries, TimelineAction.FAST_IN_OUT_CROSSING)
+        suppress_entry_decision_after_fast_exit = True
+        if magnets.get_inside_state() and magnets.check_queued("lock_inside") == False and inside_manually_unlocked == False:
+            magnets.queue_command("lock_inside")
+            unlock_inside_tm = 0.0
+            _timeline_log_inside_close(TimelineAction.INSIDE_CLOSED_FAST_IN_OUT)
+        if magnets.get_outside_state() and magnets.check_queued("lock_outside") == False:
+            if timeline_outside_reported != "closed":
+                timeline_outside_reported = "closed"
+                timeline_append(motion_timeline_entries, TimelineAction.OUTSIDE_CLOSED_FAST_IN_OUT)
+            magnets.queue_command("lock_outside")
+        suppress_outside_motion_block = True
+        suppress_inside_motion_block = True
+
+    def _finalize_motion_block(trigger_source: str = "outside_motion_end", locks_already_applied: bool = False):
         nonlocal unlock_inside_decision_made
         nonlocal tag_id_valid
         nonlocal additional_verdict_infos
@@ -582,33 +607,27 @@ def backend_main(simulate_kittyflap = False):
         nonlocal motion_block_active
         nonlocal suppress_outside_motion_block
         nonlocal suppress_inside_motion_block
+        nonlocal suppress_entry_decision_after_fast_exit
         nonlocal unlock_inside_tm
         nonlocal timeline_outside_reported
+        nonlocal pending_fast_exit_finalize_mono
 
         if not motion_block_active:
             return
 
+        pending_fast_exit_finalize_mono = 0.0
+
         if trigger_source == "outside_motion_end":
             timeline_append(motion_timeline_entries, TimelineAction.MOTION_OUTSIDE_END)
-        else:
+        elif not locks_already_applied:
             timeline_append(motion_timeline_entries, TimelineAction.FAST_IN_OUT_CROSSING)
 
         exit_in_progress = False
         unlock_inside_decision_made = False
         tag_id_valid = False
 
-        if trigger_source == "fast_in_out_crossing":
-            if magnets.get_inside_state() and magnets.check_queued("lock_inside") == False and inside_manually_unlocked == False:
-                magnets.queue_command("lock_inside")
-                unlock_inside_tm = 0.0
-                _timeline_log_inside_close(TimelineAction.INSIDE_CLOSED_FAST_IN_OUT)
-            if magnets.get_outside_state() and magnets.check_queued("lock_outside") == False:
-                if timeline_outside_reported != "closed":
-                    timeline_outside_reported = "closed"
-                    timeline_append(motion_timeline_entries, TimelineAction.OUTSIDE_CLOSED_FAST_IN_OUT)
-                magnets.queue_command("lock_outside")
-            suppress_outside_motion_block = True
-            suppress_inside_motion_block = True
+        if trigger_source == "fast_in_out_crossing" and not locks_already_applied:
+            _apply_fast_crossing_locks()
         elif (
             magnets.get_inside_state() == True
             and magnets.check_queued("lock_inside") == False
@@ -895,16 +914,32 @@ def backend_main(simulate_kittyflap = False):
             if suppress_inside_motion_block and motion_inside == 0 and motion_inside_crossing == 0:
                 suppress_inside_motion_block = False
 
+            if pending_fast_exit_finalize_mono > 0.0 and monotonic_time() >= pending_fast_exit_finalize_mono:
+                pending_fast_exit_finalize_mono = 0.0
+                last_motion_outside_tm = wall_time()
+                logging.info(
+                    f"[BACKEND] Fast-exit post-capture finished. Finalizing motion block '{motion_block_id}'."
+                )
+                _finalize_motion_block("fast_in_out_crossing", locks_already_applied=True)
+
             if last_outside == 1 and motion_outside == 0:
-                if not use_camera_for_motion:
+                if not use_camera_for_motion and pending_fast_exit_finalize_mono <= 0.0:
                     if model_handler.get_run_state() == True:
                         model_handler.pause()
                         # Wait for the last image to be processed
                         tm.sleep(0.5)
                 last_motion_outside_tm = wall_time()
                 last_motion_outside_mono = monotonic_time()
-                logging.info(f"[BACKEND] {motion_source}-based motion detection: Motion stopped OUTSIDE (Block ID: '{motion_block_id}')")
-                _finalize_motion_block("outside_motion_end")
+                if pending_fast_exit_finalize_mono > 0.0:
+                    logging.debug(
+                        "[BACKEND] Motion stopped OUTSIDE during fast-exit post-capture; "
+                        "waiting for capture timer before finalizing."
+                    )
+                else:
+                    logging.info(f"[BACKEND] {motion_source}-based motion detection: Motion stopped OUTSIDE (Block ID: '{motion_block_id}')")
+                    _finalize_motion_block("outside_motion_end")
+                if motion_inside == 0 and motion_inside_raw == 0:
+                    suppress_entry_decision_after_fast_exit = False
 
             if last_inside_raw == 1 and motion_inside_raw == 0: # Inside motion stopped (raw)
                 last_motion_inside_raw_mono = motion_inside_raw_mono
@@ -916,6 +951,8 @@ def backend_main(simulate_kittyflap = False):
                 # Publish the inside motion state to MQTT
                 if mqtt_publisher:
                     mqtt_publisher.publish_motion_inside(False)
+                if motion_outside == 0 and motion_inside_raw == 0:
+                    suppress_entry_decision_after_fast_exit = False
 
             # Start the RFID thread with infinite read cycles, if it is not running and motion is detected outside or inside
             # Note: Check this here to enable the RFID reader as soon as motion is detected
@@ -995,7 +1032,15 @@ def backend_main(simulate_kittyflap = False):
                         first_motion_inside_raw_tm = first_motion_inside_tm
                         first_motion_inside_raw_mono = first_motion_inside_mono
                     last_motion_outside_tm = wall_time()
-                    _finalize_motion_block("fast_in_out_crossing")
+                    if exit_in_progress:
+                        _apply_fast_crossing_locks()
+                        pending_fast_exit_finalize_mono = monotonic_time() + FAST_EXIT_POST_CAPTURE_SECONDS
+                        logging.info(
+                            "[BACKEND] Immediate lock after exit passage: flap locked, "
+                            f"continuing capture for {FAST_EXIT_POST_CAPTURE_SECONDS:.1f}s before finalizing event."
+                        )
+                    else:
+                        _finalize_motion_block("fast_in_out_crossing")
 
             if last_inside == 0 and motion_inside == 1 and not suppress_inside_motion_block: # Inside motion detected
                 logging.info("[BACKEND] Motion detected INSIDE")
@@ -1217,7 +1262,7 @@ def backend_main(simulate_kittyflap = False):
                         pending_exit_rfid_check = False
 
             # Check if we are allowed to open the inside direction
-            if motion_outside and not unlock_inside_decision_made:
+            if motion_outside and not unlock_inside_decision_made and not suppress_entry_decision_after_fast_exit:
                 # Skip entry decision if this motion block represents an exit
                 if exit_in_progress:
                     unlock_inside_decision_made = True

--- a/src/backend.py
+++ b/src/backend.py
@@ -431,6 +431,9 @@ def backend_main(simulate_kittyflap = False):
     suppress_outside_motion_block = False
     suppress_inside_motion_block = False
     suppress_entry_decision_after_fast_exit = False
+    # If entry was skipped because an exit was active earlier in the same motion block,
+    # keep this marker so we can log the skip once and re-evaluate later if exit ends.
+    deferred_entry_due_to_exit = False
     last_outside_crossing = 0
     last_inside_crossing = 0
     last_inside_raw_crossing = 0
@@ -624,6 +627,7 @@ def backend_main(simulate_kittyflap = False):
         nonlocal entry_unlocked_mono
         nonlocal event_cooldown_until_mono
         nonlocal pending_exit_rfid_check
+        nonlocal deferred_entry_due_to_exit
 
         if not motion_block_active:
             return
@@ -636,6 +640,7 @@ def backend_main(simulate_kittyflap = False):
         # once by _apply_fast_crossing_locks(), which is the single source for fast-crossing locks.
 
         exit_in_progress = False
+        deferred_entry_due_to_exit = False
         unlock_inside_decision_made = False
         tag_id_valid = False
 
@@ -1178,6 +1183,10 @@ def backend_main(simulate_kittyflap = False):
                 ((monotonic_time() - last_motion_inside_mono) > OPEN_OUTSIDE_TIMEOUT) and
                 (magnets.check_queued("lock_outside") == False) ):
                     magnets.queue_command("lock_outside")
+                    # Exit passage has ended from the control perspective. Keep the current
+                    # motion block alive but allow a fresh entry decision if outside motion
+                    # persists and turns into a valid entry attempt.
+                    exit_in_progress = False
                     _timeline_log_outside_close()
 
             # Check also for a cat via the camera, if the option is enabled and no RFID tag is detected
@@ -1327,10 +1336,14 @@ def backend_main(simulate_kittyflap = False):
             if motion_outside and not unlock_inside_decision_made and not suppress_entry_decision_after_fast_exit:
                 # Skip entry decision if this motion block represents an exit
                 if exit_in_progress:
-                    unlock_inside_decision_made = True
-                    timeline_append(motion_timeline_entries, TimelineAction.EXIT_SKIPPED_ENTRY)
-                    logging.info("[BACKEND] Skipping entry decision because exit is in progress for this motion block.")
+                    if not deferred_entry_due_to_exit:
+                        deferred_entry_due_to_exit = True
+                        timeline_append(motion_timeline_entries, TimelineAction.EXIT_SKIPPED_ENTRY)
+                        logging.info("[BACKEND] Skipping entry decision because exit is in progress for this motion block.")
                 else:
+                    if deferred_entry_due_to_exit:
+                        logging.info("[BACKEND] Exit flow ended while outside motion persists. Re-evaluating entry decision for current motion block.")
+                        deferred_entry_due_to_exit = False
                     identified_tag, id_source = _identified_tag_for_entry(
                         tag_id, tag_id_from_video, known_rfid_tags, CONFIG['ALLOWED_TO_ENTER']
                     )

--- a/src/baseconfig.py
+++ b/src/baseconfig.py
@@ -213,6 +213,7 @@ DEFAULT_CONFIG = {
         "kittyhack_database_backup_path": "../kittyhack_backup.db",
         "pir_outside_threshold": 0.5,
         "pir_inside_threshold": 3.0,
+        "immediate_lock_after_passage": False,
         "wlan_tx_power": 7,
         "group_pictures_to_events": True,
         "tflite_model_version": "original_kittyflap_model_v2",
@@ -479,6 +480,7 @@ def load_config():
         "KITTYHACK_DATABASE_BACKUP_PATH": safe_str("KITTYHACK_DATABASE_BACKUP_PATH", d['kittyhack_database_backup_path']),
         "PIR_OUTSIDE_THRESHOLD": safe_float("PIR_OUTSIDE_THRESHOLD", float(d['pir_outside_threshold'])),
         "PIR_INSIDE_THRESHOLD": safe_float("PIR_INSIDE_THRESHOLD", float(d['pir_inside_threshold'])),
+        "IMMEDIATE_LOCK_AFTER_PASSAGE": safe_bool("IMMEDIATE_LOCK_AFTER_PASSAGE", d.get('immediate_lock_after_passage', False)),
         "WLAN_TX_POWER": safe_int("WLAN_TX_POWER", int(d['wlan_tx_power'])),
         "GROUP_PICTURES_TO_EVENTS": safe_bool("GROUP_PICTURES_TO_EVENTS", d['group_pictures_to_events']),
         "TFLITE_MODEL_VERSION": safe_str("TFLITE_MODEL_VERSION", d['tflite_model_version']),
@@ -659,6 +661,7 @@ def save_config():
     settings['kittyhack_database_backup_path'] = CONFIG['KITTYHACK_DATABASE_BACKUP_PATH']
     settings['pir_outside_threshold'] = CONFIG['PIR_OUTSIDE_THRESHOLD']
     settings['pir_inside_threshold'] = CONFIG['PIR_INSIDE_THRESHOLD']
+    settings['immediate_lock_after_passage'] = CONFIG['IMMEDIATE_LOCK_AFTER_PASSAGE']
     settings['wlan_tx_power'] = CONFIG['WLAN_TX_POWER']
     settings['group_pictures_to_events'] = CONFIG['GROUP_PICTURES_TO_EVENTS']
     settings['tflite_model_version'] = CONFIG['TFLITE_MODEL_VERSION']

--- a/src/event_timeline.py
+++ b/src/event_timeline.py
@@ -38,6 +38,9 @@ class TimelineAction:
     OUTSIDE_CLOSED = "outside_closed"
     EVENT_CONCLUSION = "event_conclusion"
     EXIT_SKIPPED_ENTRY = "exit_skipped_entry"
+    FAST_IN_OUT_CROSSING = "fast_in_out_crossing"
+    INSIDE_CLOSED_FAST_IN_OUT = "inside_closed_fast_in_out"
+    OUTSIDE_CLOSED_FAST_IN_OUT = "outside_closed_fast_in_out"
 
 
 def timeline_append(entries: list, action: str, **detail) -> None:
@@ -102,6 +105,9 @@ def timeline_format_message(entry: dict) -> str:
         TimelineAction.OUTSIDE_OPENED: _("Outside opened"),
         TimelineAction.OUTSIDE_CLOSED: _("Outside closed"),
         TimelineAction.EXIT_SKIPPED_ENTRY: _("Entry decision skipped (exit in progress)"),
+        TimelineAction.FAST_IN_OUT_CROSSING: _("Cat crossed the flap"),
+        TimelineAction.INSIDE_CLOSED_FAST_IN_OUT: _("Inside locked (after passage)"),
+        TimelineAction.OUTSIDE_CLOSED_FAST_IN_OUT: _("Outside locked (after passage)"),
     }
 
     if action == TimelineAction.EVENT_CONCLUSION and conclusion:

--- a/src/server.py
+++ b/src/server.py
@@ -4255,8 +4255,7 @@ def server(input, output, session):
 
             block_ids = [int(b) for b in df_events['block_id'].tolist()]
             timelines_by_block = db_get_motion_timelines(CONFIG['KITTYHACK_DATABASE_PATH'], block_ids)
-            info_icon_html = str(icon_svg("circle-info", margin_left="0", margin_right="0"))
-            info_btn_title = html_module.escape(_("Show event details"))
+            event_row_title = html_module.escape(_("Show event details"))
 
             # Process event types into HTML with icons
             event_icons = {}
@@ -4296,8 +4295,6 @@ def server(input, output, session):
                     html += f'<tr class="date-separator-row"><td colspan="4" class="event-date-separator">{row["date_display"]}</td></tr>'
                     last_date = row['date_display']
                 
-                html += '<tr>'
-                html += f'<td>{row["time"]}</td>'
                 event_info = event_icons[idx]
                 block_id = int(row['block_id'])
                 panel_id = f"event-timeline-{block_id}"
@@ -4310,17 +4307,20 @@ def server(input, output, session):
                     timeline_entries = timeline_extract_latest_event(timeline_entries)
                 timeline_html = timeline_entries_to_html(timeline_entries, CONFIG['TIMEZONE'])
                 html += (
+                    f'<tr class="event-data-row kh-event-row-toggle" data-kh-panel-id="{panel_id}" '
+                    f'role="button" tabindex="0" aria-expanded="false" aria-controls="{panel_id}" '
+                    f'title="{event_row_title}">'
+                )
+                html += f'<td>{row["time"]}</td>'
+                html += (
                     f'<td><div class="event-icons-cell">'
                     f'<div class="event-icons">{event_info["icons_html"]}</div>'
-                    f'<button type="button" class="btn btn-link btn-sm event-timeline-toggle p-0 ms-1" '
-                    f'data-bs-toggle="collapse" data-bs-target="#{panel_id}" '
-                    f'aria-expanded="false" aria-controls="{panel_id}" title="{info_btn_title}">'
-                    f'{info_icon_html}</button></div></td>'
+                    f'</div></td>'
                 )
                 html += f'<td>{row["cat_name"]}</td>'
                 unique_id = hashlib.md5(os.urandom(16)).hexdigest()
                 btn_id = f"btn_show_event_{unique_id}"
-                html += f'<td><div>{btn_show_event(btn_id)}</div></td>'
+                html += f'<td class="event-action-cell"><div>{btn_show_event(btn_id)}</div></td>'
                 show_event_server(btn_id, row['block_id'])
                 html += '</tr>'
                 html += (

--- a/src/server.py
+++ b/src/server.py
@@ -7380,6 +7380,28 @@ def server(input, output, session):
                                 )
                             )
                         ),
+                        ui.hr(),
+                        ui.row(
+                            ui.column(
+                                12,
+                                ui.input_switch(
+                                    "btnImmediateLockAfterPassage",
+                                    _("Immediate locking after passage"),
+                                    CONFIG['IMMEDIATE_LOCK_AFTER_PASSAGE'],
+                                    width="90%",
+                                )
+                            ),
+                            ui.column(
+                                12,
+                                info_toggle(
+                                    "immediate_lock_after_passage_info",
+                                    _("About this feature"),
+                                    _("When enabled, the flap locks again and the motion event is finalized as soon as motion is detected on the opposite side of the flap (cat has crossed).") + "  \n\n" +
+                                    _("This feature is useful if your cat is very fast and the flap should not remain open for too long. Will help prevent multiple cats from using the flap in quick succession.") + "  \n\n" +
+                                    _("If your cat is shy or just needs several attempts to cross, you should not enable this feature. Otherwise, the flap could be accidentally locked while your cat is still trying to cross.")
+                                )
+                            )
+                        ),
                         full_screen=False,
                         class_="generic-container align-left",
                         style_="padding-left: 1rem !important; padding-right: 1rem !important;",
@@ -8158,6 +8180,7 @@ def server(input, output, session):
         # TODO: Outside PIR shall not yet be configurable. Need to redesign the camera control, otherwise we will have no cat pictures at high PIR thresholds.
         #CONFIG['PIR_OUTSIDE_THRESHOLD'] = 10-int(input.sldPirOutsideThreshold())
         CONFIG['PIR_INSIDE_THRESHOLD'] = float(input.sldPirInsideThreshold())
+        CONFIG['IMMEDIATE_LOCK_AFTER_PASSAGE'] = input.btnImmediateLockAfterPassage()
         if not is_remote_mode():
             CONFIG['WLAN_TX_POWER'] = int(input.sldWlanTxPower())
         CONFIG['LOCK_DURATION_AFTER_PREY_DETECTION'] = int(input.sldLockAfterPreyDetect())

--- a/www/app.js
+++ b/www/app.js
@@ -309,6 +309,58 @@ document.addEventListener("DOMContentLoaded", function() {
 
     initLiveViewPlaceholderAutoFit();
 
+    // --- Events table: row click toggles timeline details ---
+    // Use explicit click handling so nested action buttons (open modal, etc.)
+    // do not conflict with Bootstrap's delegated collapse data API.
+    function khToggleEventTimelineRow(row) {
+        if (!row || !row.getAttribute) return;
+        const panelId = row.getAttribute('data-kh-panel-id');
+        if (!panelId) return;
+
+        const panel = document.getElementById(panelId);
+        if (!panel) return;
+
+        const isShown = panel.classList.contains('show');
+        if (window.bootstrap && window.bootstrap.Collapse) {
+            try {
+                const inst = window.bootstrap.Collapse.getOrCreateInstance(panel, { toggle: false });
+                if (isShown) {
+                    inst.hide();
+                } else {
+                    inst.show();
+                }
+            } catch (e) {
+                panel.classList.toggle('show', !isShown);
+            }
+        } else {
+            panel.classList.toggle('show', !isShown);
+        }
+
+        row.setAttribute('aria-expanded', isShown ? 'false' : 'true');
+    }
+
+    function khShouldIgnoreEventRowToggle(target) {
+        if (!target || !target.closest) return false;
+        return !!target.closest(
+            'a, button, input, select, textarea, label, .event-action-cell, [data-bs-toggle="tooltip"]'
+        );
+    }
+
+    document.addEventListener('click', function(ev) {
+        const row = ev.target && ev.target.closest ? ev.target.closest('.kh-event-row-toggle') : null;
+        if (!row) return;
+        if (khShouldIgnoreEventRowToggle(ev.target)) return;
+        khToggleEventTimelineRow(row);
+    }, false);
+
+    document.addEventListener('keydown', function(ev) {
+        const row = ev.target && ev.target.closest ? ev.target.closest('.kh-event-row-toggle') : null;
+        if (!row) return;
+        if (ev.key !== 'Enter' && ev.key !== ' ') return;
+        ev.preventDefault();
+        khToggleEventTimelineRow(row);
+    }, false);
+
     // --- Event modal: show spinner until first image is rendered ---
     function syncEventModalSpinner(root) {
         const scope = root && root.querySelector ? root : document;

--- a/www/styles.css
+++ b/www/styles.css
@@ -1101,14 +1101,21 @@ html[data-bs-theme="dark"] .date-separator-row td {
   gap: 0.25rem;
 }
 
-.event-timeline-toggle {
-  line-height: 1;
-  color: var(--bs-secondary-color, #6c757d);
+.event-data-row {
+  cursor: pointer;
 }
 
-.event-timeline-toggle:hover,
-.event-timeline-toggle:focus {
-  color: var(--bs-primary, #0d6efd);
+.event-data-row:hover {
+  background-color: var(--bs-tertiary-bg, rgba(0, 0, 0, 0.03));
+}
+
+.event-data-row:focus-visible {
+    outline: 2px solid var(--bs-primary, #0d6efd);
+    outline-offset: -2px;
+}
+
+.event-data-row .event-action-cell {
+  cursor: default;
 }
 
 .event-timeline-panel {


### PR DESCRIPTION
## New Feature
- **Immediate locking after passage (optional)**: A new setting under *Configuration* can lock the flap immediately once the cat is detected on the opposite side (crossing completed). This can reduce the time the flap remains open and helps reducing quick follow-up passages of other cats.

## Bugfixes
- **Intermittently blocked entry direction**: In certain configurations, cats were occasionally unable to enter anymore. This issue has now been fixed.

## Improvements
- **Better expandable event details on mobile**: Event details are now expand/collapse via a simple click on the event row.